### PR TITLE
Don't output colors when stderr is *not* a TTY.

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -36,6 +36,14 @@ var colors = [6, 2, 3, 4, 5, 1];
 var prevColor = 0;
 
 /**
+ * Is stderr a TTY? Colored output is disabled when `true`.
+ */
+
+var isTTY = 'isTTY' in process.stderr
+          ? process.stderr.isTTY
+          : process.binding('stdio').isatty(process.stderr.fd || 2)
+
+/**
  * Select a color.
  *
  * @return {Number}
@@ -57,8 +65,13 @@ function color() {
 function debug(name) {
   if (!~names.indexOf(name)) return function(){};
   var c = color();
-  return function(fmt){
+  return isTTY ?
+  function(fmt){
     fmt = '  \033[3' + c + 'm' + name + '\033[90m ' + fmt + '\033[0m';
+    console.error.apply(this, arguments);
+  } :
+  function(fmt){
+    fmt = '  ' + name + ' ' + fmt;
     console.error.apply(this, arguments);
   }
 }


### PR DESCRIPTION
For piping to a `gist` command or whatever:

![](http://f.cl.ly/items/3z42121e1H152a2C2K3E/Screen%20Shot%202011-12-02%20at%202.56.51%20PM.png)
