### PR TITLE
Flips documentation from "true" to "false"

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,4 +1,3 @@
-
 /*!
  * debug
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -42,11 +41,10 @@ var colors = [6, 2, 3, 4, 5, 1];
 var prevColor = 0;
 
 /**
- * Is stderr a TTY? Colored output is disabled when `true`.
+ * Is stderr a TTY, or is the -forcecolor flag on? Colored output is enabled when `true`.
  */
 
-var isatty = tty.isatty(process.stderr.fd || 2);
-
+var shouldicolor = tty.isatty(process.stderr.fd || 2) || names.indexOf("-forcecolor") > -1;
 /**
  * Select a color.
  *
@@ -80,5 +78,5 @@ function debug(name) {
     console.error.apply(this, arguments);
   }
 
-  return isatty ? colored : plain;
+  return shouldicolor ? colored : plain;
 }


### PR DESCRIPTION
The docs are mislabeled here... if something is a tty, then color happens. If it's not, then color doesn't happen.
