### PR TITLE
debug: add an `enabled` flag to the returned debug function

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -105,17 +105,20 @@ function humanize(ms) {
  */
 
 function debug(name) {
+  function disabled(){}
+  disabled.enabled = false;
+
   var match = skips.some(function(re){
     return re.test(name);
   });
 
-  if (match) return function(){};
+  if (match) return disabled;
 
   match = names.some(function(re){
     return re.test(name);
   });
 
-  if (!match) return function(){};
+  if (!match) return disabled;
   var c = color();
 
   function colored(fmt) {
@@ -136,6 +139,8 @@ function debug(name) {
       + ' ' + name + ' ' + fmt;
     console.error.apply(this, arguments);
   }
+
+  colored.enabled = plain.enabled = true;
 
   return isatty
     ? colored


### PR DESCRIPTION
So that you can do things conditionally if debug mode is enabled.

Closes #11.
