### PR TITLE
A way to force colored output

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -129,7 +128,7 @@ function debug(name) {
 
   colored.enabled = plain.enabled = true;
 
-  return isatty || (process.env['DEBUG_COLORED'] == 'true')
+  return isatty || process.env.DEBUG_COLORS
     ? colored
     : plain;
 }


### PR DESCRIPTION
Added DEBUG_COLORED environnement variable to force colored output (required when using tools like nodemon).
