### PR TITLE
Expose debug.colored and debug.colors

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -33,7 +33,7 @@ var names = []
  * Colors.
  */
 
-var colors = [6, 2, 3, 4, 5, 1];
+debug.colors = [2, 3, 4, 5, 1, 6];
 
 /**
  * Previous debug() call.
@@ -51,7 +51,7 @@ var prevColor = 0;
  * Is stdout a TTY? Colored output is disabled when `true`.
  */
 
-var isatty = tty.isatty(2);
+debug.colored = tty.isatty(2);
 
 /**
  * Select a color.
@@ -61,7 +61,7 @@ var isatty = tty.isatty(2);
  */
 
 function color() {
-  return colors[prevColor++ % colors.length];
+  return debug.colors[prevColor++ % debug.colors.length];
 }
 
 /**
@@ -114,7 +114,7 @@ function debug(name) {
     prev[name] = curr;
 
     fmt = '  \033[9' + c + 'm' + name + ' '
-      + '\033[3' + c + 'm\033[90m'
+      + '\033[3' + c + 'm' + '\033[0m' //+ '\033[90m'
       + fmt + '\033[3' + c + 'm'
       + ' +' + humanize(ms) + '\033[0m';
 
@@ -129,7 +129,7 @@ function debug(name) {
 
   colored.enabled = plain.enabled = true;
 
-  return isatty
+  return debug.colored
     ? colored
     : plain;
 }


### PR DESCRIPTION
Not ideal, but someone can found this usefull.

Feel free to keep this open for discussion.

See also #17 - A way to force colored output, this patch NOT solving this via ENV variable.
