### PR TITLE
[de,bug] = debug.faster(name); de&&bug("faster")

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,4 +1,3 @@
-
 /**
  * Expose `debug()` as the module.
  */
@@ -116,6 +115,24 @@ debug.enabled = function(name) {
   }
   return false;
 };
+
+/**
+ * Returns CoffeeScript and "de&&bug" friendly combined results
+ * of debug() and enabled()
+ *
+ * @param {String} name
+ * @return {[Boolean,Function]}
+ * @api public
+ *
+ *  Usage:
+ *    [de,bug] = debug.faster( name)
+ *    de&&bug( "with less overhead")
+ */
+
+debug.faster = function(name) {
+  return [debug.enabled(name),debug(name)];
+};
+
 
 // persist
 


### PR DESCRIPTION
When a mode is disabled, there remains some significant overhead due to the evaluation of the parameter sent to the debugger. i.e. that parameter is actually discarded by the noop debugger. So, why should we built it in the first place?

A solution is to invoke the debugger only when it is enabled. This requires an additional flag. debug.faster() returns both that flag and the debugger.

The "de&&bug" pattern is a somehow "hacky" way to use these results.

Benefits: reduces the need to remove tracing instrumentation from production code, may help debugging in these situations.

Cheers.

    Jean Hugues
