### PR TITLE
Mobile Safari (private mode) is broken with debug

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -50,7 +50,9 @@ debug.skips = [];
  */
 
 debug.enable = function(name) {
-  localStorage.debug = name;
+  try {
+    localStorage.debug = name;
+  } catch(e){}
 
   var split = (name || '').split(/[\s,]+/)
     , len = split.length;


### PR DESCRIPTION
Mobile Safari has a dumb feature where it goes ahead and throws an exception when trying to access the localStorage in private mode.  

Other people with the same issue: 
http://meta.stackoverflow.com/questions/123116/safari-5-1-2-log-in-doesnt-work  

Simply wrapping the local storage access in a try/catch should do the trick...
