### PR TITLE
Cache regexp test function, use Date.now()

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -94,21 +94,17 @@ function debug(name) {
   function disabled(){}
   disabled.enabled = false;
 
-  var match = skips.some(function(re){
+  function test(re){
     return re.test(name);
-  });
+  }
 
-  if (match) return disabled;
+  if (skips.some(test)) return disabled;
+  if (names.some(test)) return disabled;
 
-  match = names.some(function(re){
-    return re.test(name);
-  });
-
-  if (!match) return disabled;
   var c = color();
 
   function colored(fmt) {
-    var curr = new Date;
+    var curr = Date.now();
     var ms = curr - (prev[name] || curr);
     prev[name] = curr;
 


### PR DESCRIPTION
Just two very small changes that improve mainly the readability (no more conversions of date objects to numbers, one function and a variable less).
