### PR TITLE
humanize ms with a sub-unit

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -91,9 +91,9 @@ debug.humanize = function(ms) {
     , min = 60 * 1000
     , hour = 60 * min;
 
-  if (ms >= hour) return (ms / hour).toFixed(1) + 'h';
-  if (ms >= min) return (ms / min).toFixed(1) + 'm';
-  if (ms >= sec) return (ms / sec | 0) + 's';
+  if (ms >= hour) return (ms / hour).toFixed(1) + 'h' + (ms % hour) + 'm';
+  if (ms >= min) return (ms / min).toFixed(1) + 'm' + (ms % min) + 's';
+  if (ms >= sec) return (ms / sec | 0) + 's' + (ms % sec) + 'ms';
   return ms + 'ms';
 };
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -76,9 +76,9 @@ function humanize(ms) {
     , min = 60 * 1000
     , hour = 60 * min;
 
-  if (ms >= hour) return (ms / hour).toFixed(1) + 'h';
-  if (ms >= min) return (ms / min).toFixed(1) + 'm';
-  if (ms >= sec) return (ms / sec | 0) + 's';
+  if (ms >= hour) return (ms / hour).toFixed(1) + 'h' + (ms % hour) + 'm';
+  if (ms >= min) return (ms / min).toFixed(1) + 'm' + (ms % min) + 's';
+  if (ms >= sec) return (ms / sec | 0) + 's' + (ms % sec) + 'ms';
   return ms + 'ms';
 }
 


### PR DESCRIPTION
Sometimes the remainder matters, from:

```
plist parseStringSync ... +0ms
plist parseStringSync. +1s
```

to:

```
plist parseStringSync ... +0ms
plist parseStringSync. +1s928ms
```
