### PR TITLE
Use reset instead of grey for the color() based debug message.

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -115,7 +115,7 @@ function debug(name) {
     prev[name] = curr;
 
     fmt = '  \u001b[9' + c + 'm' + name + ' '
-      + '\u001b[3' + c + 'm\u001b[90m'
+      + '\u001b[3' + c + 'm\u001b[0m'
       + fmt + '\u001b[3' + c + 'm'
       + ' +' + humanize(ms) + '\u001b[0m';
 


### PR DESCRIPTION
On a dark background, 256 colour terminal I can't read the debug message. This minor patch solves it and should make the text visible on any terminal.
