### PR TITLE
Catch localStorage security error when cookies are blocked (Chrome)

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -132,4 +132,6 @@ function coerce(val) {
 
 // persist
 
-if (window.localStorage) debug.enable(localStorage.debug);
+try {
+  if (window.localStorage) debug.enable(localStorage.debug);
+} catch(e){}


### PR DESCRIPTION
Hi,

If cookies are disabled on Chrome, `window.localStorage` throws an error
`Uncaught Error: SecurityError: DOM Exception 18`
