### PR TITLE
Browserify already picks up the 'browser' property

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   , "dependencies": {}
   , "devDependencies": { "mocha": "*" }
   , "main": "lib/debug.js"
-  , "browserify": "debug.js"
   , "browser": "./debug.js"
   , "engines": { "node": "*" }
   , "files": [


### PR DESCRIPTION
The "browserify" field actually does not even work for me with a current browserify version, but removing it, makes browserify work correctly based on the "browser" field.
