### PR TITLE
Remove "browserify" key from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   , "dependencies": {}
   , "devDependencies": { "mocha": "*" }
   , "main": "lib/debug.js"
-  , "browserify": "debug.js"
   , "browser": "./debug.js"
   , "engines": { "node": "*" }
   , "files": [


### PR DESCRIPTION
Trying to browserify debug produces an error message:

```
Error: Cannot find module 'debug.js'
```

This is because it thinks debug.js is a browserify transform since "browserify" is a [transform key](https://github.com/substack/node-browserify/blob/99fec626162ded9ec54487cd1addf18805d27854/index.js#L193). The "browser" key is probably what you want, and it's already set correctly.

Not sure how this ever worked, possibly some recent change in browserify, but I can't see exactly what.

This will need a republish on npm.
