### PR TITLE
support for colored output in strict mode

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -114,7 +114,7 @@ function debug(name) {
     var ms = curr - (prev[name] || curr);
     prev[name] = curr;
 
-    fmt = '  \u001b[9' + c + 'm' + name + ' '
+    arguments[0] = '  \u001b[9' + c + 'm' + name + ' '
       + '\u001b[3' + c + 'm\u001b[90m'
       + fmt + '\u001b[3' + c + 'm'
       + ' +' + humanize(ms) + '\u001b[0m';


### PR DESCRIPTION
in strict mode, altering named parameter of a function does not update the arguments quasi-array, this PR fixes the issue, that no colors, nor debug name and time difference is shown in strict mode
