### PR TITLE
fn.narrow() method to create new debug function based on existing one.

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -90,9 +90,31 @@ function humanize(ms) {
  * @api public
  */
 
-function debug(name) {
+function debug(name, root) {
+  
+  function letNarrow(fn) {
+    // to a given function `fn` adds a method `.narrow`
+    // this method takes a `suffix` argument
+    // and returns a copy of the `fn` with `suffix` appended `name`.
+    // additionaly adds .name property
+    // and .root property, which holds function created without .narrow
+
+    fn.scope = name
+    if (typeof root == "function") fn.root = root
+    else fn.root = fn
+    // fn.root = root // a function created with call to debug(), not .narrow()
+
+    fn.narrow = function (suffix) {
+      var scope = this.scope ? this.scope + ":" : "";
+      scope    += suffix
+      return debug(scope, fn.root)
+    };
+  }
+
   function disabled(){}
   disabled.enabled = false;
+
+  letNarrow(disabled);
 
   var match = skips.some(function(re){
     return re.test(name);
@@ -131,6 +153,10 @@ function debug(name) {
   }
 
   colored.enabled = plain.enabled = true;
+
+  [colored, plain].forEach(function (fn) { 
+    letNarrow(fn)
+  });
 
   return isatty || process.env.DEBUG_COLORS
     ? colored


### PR DESCRIPTION
Hi,

would you please take a look at this enhancement to Debug?

In node I use namespaces a lot with debug, often like that:

``` javascript
var $ = debug ("myProject");
$ ("Woohoo! Starting app!");

var doStuff = function (...) {
  var $ = debug("myProject:doStuff");
  $ ("Doing some stuff");
}
doSomethingAsync (function myCallback (...) {
  $ = debug("myProject:somethingAsync");
  $ ("Doing something async");
  doStuff();
});
```

As you can guess it quickly gets very repetitive (`myProject:doSomething:doSomethingNested:...` - several levels deep) and error prone.

So I came up with idea to have something like:

``` javascript
var $ = debug ("myProject");
$ ("Starting app");
var doStuff = function(...) {
  var $ = $.narrow("doStuff");
  $ ("Doing it!"); // myProject:doStuff: Doing it!
}
$ ("Something else"); // myProject: Something else
```

I called it `narrow` because it narrows the scope of debug messages.

As a side product I had to add `.scope` property which indicates current scope (eg. `"myProject:doStuff"`), and `.root` property which points to a first function created with call to `debug()`. Every function created with `.narrow()` has `.root` pointing to the _mother function_. So inside `doStuff` you can do for example `$.root.scope` to get `"myProject"`, or $.root("msg") to call root debug function directly.

Please let me know what do you think.
