### PR TITLE
Add option to forcefully disable colors

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -90,7 +90,7 @@ function humanize(ms) {
  * @api public
  */
 
-function debug(name) {
+function debug(name, useColors) {
   function disabled(){}
   disabled.enabled = false;
 
@@ -131,6 +131,10 @@ function debug(name) {
   }
 
   colored.enabled = plain.enabled = true;
+
+  if (typeof useColors !== 'undefined' && !useColors) {
+    return plain;
+  }
 
   return isatty || process.env.DEBUG_COLORS
     ? colored


### PR DESCRIPTION
Useful for things like node-webkit, where we have a tty
but logs are printed through the webinspector, which does
not support colors
