### PR TITLE
package: re-add the "component" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,4 +14,9 @@
       "lib/debug.js",
       "debug.js"
     ]
+  , "component": {
+      "scripts": {
+        "debug/index.js": "debug.js"
+      }
+    }
 }


### PR DESCRIPTION
Was inadvertently removed in a1cf28776451b58f322519ede9f9c0076cac1345.

The "component" section is only used by legacy build systems at this
point, but removing this broke our Cloudup build when we tried to
update to v0.8.0 of `debug`. Adding it back for v0.8.1 so that
we can upgrade again.
