### PR TITLE
Reset default terminal color for main string

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -104,8 +104,7 @@ function debug(name) {
     prev[name] = curr;
 
     fmt = '  \u001b[9' + c + 'm' + name + ' '
-      + '\u001b[3' + c + 'm\u001b[90m'
-      + fmt + '\u001b[3' + c + 'm'
+      + '\u001b[0m' + fmt + '\u001b[3' + c + 'm' 
       + ' +' + humanize(ms) + '\u001b[0m';
 
     console.log.apply(this, arguments);


### PR DESCRIPTION
Black on black isn't great for reading
https://github.com/visionmedia/debug/pull/59
