### PR TITLE
Returns the value of debug.enable()

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -14,7 +14,8 @@ module.exports = debug;
  */
 
 function debug(name) {
-  if (!debug.enabled(name)) return function(){};
+  var enabled = debug.enabled(name);
+  if (!enabled) return function(){ return false };
 
   return function(fmt){
     fmt = coerce(fmt);
@@ -33,6 +34,8 @@ function debug(name) {
     window.console
       && console.log
       && Function.prototype.apply.call(console.log, console, arguments);
+
+    return true;
   }
 }
 


### PR DESCRIPTION
See example:

``` js
var debug = require('debug')('alert');
if (!debug('sent a fake email')) {
  myRealSentMailFunction();
}
```

I think it is better if debug's `fmt` function could returns the value if debugging.
:)
