### PR TITLE
fixed browser module bug

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -3,7 +3,9 @@
  * Expose `debug()` as the module.
  */
 
-module.exports = debug;
+if(typeof module !== 'undefined'){
+  module.exports = debug;
+}
 
 /**
  * Create a debugger with the given `name`.


### PR DESCRIPTION
Fixes an issue where debug.js throws an uncaught error: `Uncaught ReferenceError: module is not defined` stopping all scripts from executing.

This should allow the module to be used in the browser and node without modification or other hack/workarounds.
