### PR TITLE
browser: add colors for WebKit browsers and Firebug

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -30,11 +30,19 @@ var colors = [
 var prevColor = 0;
 
 /**
- * Currently only WebKit-based Web Inspectors are known
- * to support "%c" CSS customizations.
+ * Currently only WebKit-based Web Inspectors and the Firebug
+ * extension (*not* the built-in Firefox web inpector) are
+ * known to support "%c" CSS customizations.
+ *
+ * TODO: add a `localStorage` variable to explicitly enable/disable colors
  */
 
-var useColors = 'WebkitAppearance' in document.documentElement.style;
+var useColors =
+  // is webkit? http://stackoverflow.com/a/16459606/376773
+  ('WebkitAppearance' in document.documentElement.style) ||
+  // is firebug? http://stackoverflow.com/a/398120/376773
+  (window.console && (console.firebug || (console.exception && console.table)));
+
 
 /**
  * Select a color.


### PR DESCRIPTION
Based off of the implementation from #67, except this one matches the Node.js colored output exactly, including the trailing `diff` value.

![screen shot 2014-05-30 at 10 43 27 pm](https://cloud.githubusercontent.com/assets/71256/3139768/b98c5fd8-e8ef-11e3-862a-f7253b6f47c6.png)

From here I want to abstract the common "colorizing" logic into the common `debug.js` file, to DRY up the node and browser files a bit more.

/cc @Buritica @netwjx @lvivier @zackbloom
