### PR TITLE
debug: use "ms" module for humanizing the diff

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,5 +9,7 @@
     "browser.js",
     "debug.js"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "guille/ms.js": "0.6.1"
+  }
 }

--- a/debug.js
+++ b/debug.js
@@ -11,7 +11,7 @@ exports.coerce = coerce;
 exports.disable = disable;
 exports.enable = enable;
 exports.enabled = enabled;
-exports.humanize = humanize;
+exports.humanize = require('ms');
 
 /**
  * The currently active debug mode names, and names to skip.
@@ -81,25 +81,6 @@ function enable(namespaces) {
 
 function disable() {
   exports.enable('');
-}
-
-/**
- * Humanize the given `ms`.
- *
- * @param {Number} m
- * @return {String}
- * @api private
- */
-
-function humanize(ms) {
-  var sec = 1000;
-  var min = 60 * 1000;
-  var hour = 60 * min;
-
-  if (ms >= hour) return (ms / hour).toFixed(1) + 'h';
-  if (ms >= min) return (ms / min).toFixed(1) + 'm';
-  if (ms >= sec) return (ms / sec | 0) + 's';
-  return ms + 'ms';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   , "description": "small debugging utility"
   , "keywords": ["debug", "log", "debugger"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
-  , "dependencies": {}
+  , "dependencies": {
+      "ms": "0.6.2"
+    }
   , "devDependencies": { "mocha": "*" }
   , "main": "./node.js"
   , "browser": "./browser.js"


### PR DESCRIPTION
This would be the first external dependency for `debug`, therefore it's slightly controversial.

@visionmedia Any thoughts on yay or nay on this?

Related to #43, #8.
