### PR TITLE
Ensure the timestamp is directly after the namespace

### DIFF
--- a/node.js
+++ b/node.js
@@ -64,10 +64,10 @@ function log() {
   if (useColors) {
     var c = this.color;
 
-    args[0] = '  \u001b[9' + c + 'm' + name + ' '
-      + '\u001b[0m'
-      + args[0] + '\u001b[3' + c + 'm'
-      + ' +' + exports.humanize(this.diff) + '\u001b[0m';
+    args[0] = '  \u001b[9' + c + 'm' + name
+      + '\u001b[0m' + '\u001b[3' + c + 'm'
+      + ' +' + exports.humanize(this.diff) + '\u001b[0m'
+      + ' ' + args[0];
   } else {
     args[0] = new Date().toUTCString()
       + ' ' + name + ' ' + args[0];


### PR DESCRIPTION
The timestamp was being printed after the first argument which would lead to things like this

```
var debug = require("debug")("test");

debug("First", "Second", "Third");
// Would print "test First +0ms Second Third"
// When it should print "test +0ms First Second Third"
```
