### PR TITLE
Don't set DEBUG if namespaces is undefined.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -103,7 +103,11 @@ function log() {
 
 function save(namespaces) {
   try {
-    localStorage.debug = namespaces;
+    if (null == namespaces) {
+      delete localStorage.debug;
+    } else {
+      localStorage.debug = namespaces;
+    }
   } catch(e) {}
 }
 

--- a/node.js
+++ b/node.js
@@ -84,7 +84,13 @@ function log() {
  */
 
 function save(namespaces) {
-  process.env.DEBUG = namespaces;
+  if (null == namespaces) {
+    // If you set a process.env field to null or undefined, it gets cast to the
+    // string 'null' or 'undefined'. Just delete instead.
+    delete process.env.DEBUG;
+  } else {
+    process.env.DEBUG = namespaces;
+  }
 }
 
 /**


### PR DESCRIPTION
On Node.js, if you set a process.env field to either null or undefined,
it gets cast to string 'null' or 'undefined'.

For debug, this means that if you don't have DEBUG set, it will get set
to the string 'undefined'. There are other modules (like
node-rest-client) which use the DEBUG environment variable that will
start spewing debug output when you don't want it to.
