### PR TITLE
Make console.x configurable.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,6 +96,32 @@ setInterval(function(){
 
   ![](https://cloud.githubusercontent.com/assets/71256/3139768/b98c5fd8-e8ef-11e3-862a-f7253b6f47c6.png)
 
+### stderr vs stdout
+
+You can set an alternative logging method per-namespace by overriding the `log` method on a per-namespace or globally:
+
+Example _stderr.js_:
+
+```js
+var debug = require('../');
+var log = debug('app:log');
+
+// by default console.log is used
+log('goes to stdout!');
+
+var error = debug('app:error');
+// set this namespace to log via console.error
+error.log = console.error.bind(console); // don't forget to bind to console!
+error('goes to stderr');
+log('still goes to stdout!');
+
+// set all output to go via console.warn
+// overrides all per-namespace log settings
+debug.log = console.warn.bind(console);
+log('now goes to stderr via console.warn');
+error('still goes to stderr, but via console.warn now');
+```
+
 ## Authors
 
  - TJ Holowaychuk

--- a/debug.js
+++ b/debug.js
@@ -110,7 +110,11 @@ function debug(namespace) {
       return match;
     });
 
-    exports.log.apply(self, args);
+    if ('function' === typeof exports.formatArgs) {
+      args = exports.formatArgs.apply(self, args);
+    }
+    var logFn = exports.log || enabled.log || console.log.bind(console);
+    logFn.apply(self, args);
   }
   enabled.enabled = true;
 

--- a/dist/debug.js
+++ b/dist/debug.js
@@ -8,6 +8,7 @@
 
 exports = module.exports = _dereq_('./debug');
 exports.log = log;
+exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
@@ -48,14 +49,14 @@ exports.formatters.j = function(v) {
   return JSON.stringify(v);
 };
 
+
 /**
- * Invokes `console.log()` when available.
- * No-op when `console.log` is not a "function".
+ * Colorize log arguments if enabled.
  *
  * @api public
  */
 
-function log() {
+function formatArgs() {
   var args = arguments;
   var useColors = this.useColors;
 
@@ -66,33 +67,43 @@ function log() {
     + (useColors ? '%c ' : ' ')
     + '+' + exports.humanize(this.diff);
 
-  if (useColors) {
-    var c = 'color: ' + this.color;
-    args = [args[0], c, ''].concat(Array.prototype.slice.call(args, 1));
+  if (!useColors) return args
 
-    // the final "%c" is somewhat tricky, because there could be other
-    // arguments passed either before or after the %c, so we need to
-    // figure out the correct index to insert the CSS into
-    var index = 0;
-    var lastC = 0;
-    args[0].replace(/%[a-z%]/g, function(match) {
-      if ('%%' === match) return;
-      index++;
-      if ('%c' === match) {
-        // we only are interested in the *last* %c
-        // (the user may have provided their own)
-        lastC = index;
-      }
-    });
+  var c = 'color: ' + this.color;
+  args = [args[0], c, ''].concat(Array.prototype.slice.call(args, 1));
 
-    args.splice(lastC, 0, c);
-  }
+  // the final "%c" is somewhat tricky, because there could be other
+  // arguments passed either before or after the %c, so we need to
+  // figure out the correct index to insert the CSS into
+  var index = 0;
+  var lastC = 0;
+  args[0].replace(/%[a-z%]/g, function(match) {
+    if ('%%' === match) return;
+    index++;
+    if ('%c' === match) {
+      // we only are interested in the *last* %c
+      // (the user may have provided their own)
+      lastC = index;
+    }
+  });
 
+  args.splice(lastC, 0, c);
+  return args;
+}
+
+/**
+ * Invokes `console.log()` when available.
+ * No-op when `console.log` is not a "function".
+ *
+ * @api public
+ */
+
+function log() {
   // This hackery is required for IE8,
   // where the `console.log` function doesn't have 'apply'
   return 'object' == typeof console
     && 'function' == typeof console.log
-    && Function.prototype.apply.call(console.log, console, args);
+    && Function.prototype.apply.call(console.log, console, arguments);
 }
 
 /**
@@ -246,7 +257,11 @@ function debug(namespace) {
       return match;
     });
 
-    exports.log.apply(self, args);
+    if ('function' === typeof exports.formatArgs) {
+      args = exports.formatArgs.apply(self, args);
+    }
+    var logFn = exports.log || enabled.log || console.log.bind(console);
+    logFn.apply(self, args);
   }
   enabled.enabled = true;
 

--- a/example/browser.html
+++ b/example/browser.html
@@ -10,6 +10,10 @@
       var a = debug('worker:a');
       var b = debug('worker:b');
 
+      // set all output to go via console.info
+      // instead of console.log
+      debug.log = console.info.bind(console);
+
       setInterval(function(){
         a('doing some work');
       }, 1000);

--- a/example/stderr.js
+++ b/example/stderr.js
@@ -1,0 +1,17 @@
+var debug = require('../');
+var log = debug('app:log');
+
+// by default console.log is used
+log('goes to stdout!');
+
+var error = debug('app:error');
+// set this namespace to log via console.error
+error.log = console.error.bind(console); // don't forget to bind to console!
+error('goes to stderr');
+log('still goes to stdout!');
+
+// set all output to go via console.warn
+// overrides all per-namespace log settings
+debug.log = console.warn.bind(console);
+log('now goes to stderr via console.warn');
+error('still goes to stderr, but via console.warn now');

--- a/node.js
+++ b/node.js
@@ -14,6 +14,7 @@ var util = require('util');
 
 exports = module.exports = require('./debug');
 exports.log = log;
+exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
@@ -50,13 +51,12 @@ exports.formatters.o = function(v) {
 };
 
 /**
- * Invokes `console.log()` with the specified arguments,
- * after adding ANSI color escape codes if enabled.
+ * Adds ANSI color escape codes if enabled.
  *
  * @api public
  */
 
-function log() {
+function formatArgs() {
   var args = arguments;
   var useColors = this.useColors;
   var name = this.namespace;
@@ -72,8 +72,15 @@ function log() {
     args[0] = new Date().toUTCString()
       + ' ' + name + ' ' + args[0];
   }
+  return args;
+}
 
-  console.log.apply(console, args);
+/**
+ * Invokes `console.log()` with the specified arguments.
+ */
+
+function log() {
+  return console.log.apply(console, arguments);
 }
 
 /**


### PR DESCRIPTION
Currently it is impossible to direct only `debug` output to stderr. This patch allows the specific console.x method to be configured.
