### PR TITLE
Find node path using shell/which.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ THIS_DIR:=$(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 BIN := $(THIS_DIR)/node_modules/.bin
 
 # applications
-NODE ?= node
+NODE ?= $(shell which node)
 NPM ?= $(NODE) $(shell which npm)
 BROWSERIFY ?= $(NODE) $(BIN)/browserify
 


### PR DESCRIPTION
Without this patch, Make would fail with the following error:

```
> make
/bin/sh: node: command not found
make: *** [node_modules] Error 127
```

This may be something strange about my computer's configuration, but seems like a harmless change that makes the build more robust.
