### PR TITLE
Fixed module name in dependency require

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -11,7 +11,7 @@ exports.coerce = coerce;
 exports.disable = disable;
 exports.enable = enable;
 exports.enabled = enabled;
-exports.humanize = require('ms');
+exports.humanize = require('ms.js');
 
 /**
  * The currently active debug mode names, and names to skip.


### PR DESCRIPTION
The dependency is declared as "guille/ms.js", but the require was being made with `ms` only. 
Not sure about the build using `component` utility but using Webpack this breaks the build.
