### PR TITLE
node.js: Use stderr rather than stdout for logging

### DIFF
--- a/node.js
+++ b/node.js
@@ -87,11 +87,11 @@ function formatArgs() {
 }
 
 /**
- * Invokes `console.log()` with the specified arguments.
+ * Invokes `console.error()` with the specified arguments.
  */
 
 function log() {
-  return console.log.apply(console, arguments);
+  return console.error.apply(console, arguments);
 }
 
 /**


### PR DESCRIPTION
Closes #120
