### PR TITLE
Adds check to useColors for worker contexts

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -46,12 +46,14 @@ exports.colors = [
 
 function useColors() {
   // is webkit? http://stackoverflow.com/a/16459606/376773
-  return ('WebkitAppearance' in document.documentElement.style) ||
+  return typeof ServiceWorkerGlobalScope == "undefined" && (
+    'WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
     (window.console && (console.firebug || (console.exception && console.table))) ||
     // is firefox >= v31?
     // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
-    (navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31);
+    (navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31)
+  );
 }
 
 /**

--- a/browser.js
+++ b/browser.js
@@ -47,7 +47,7 @@ exports.colors = [
 function useColors() {
   // is webkit? http://stackoverflow.com/a/16459606/376773
   return typeof ServiceWorkerGlobalScope == "undefined" && (
-    'WebkitAppearance' in document.documentElement.style) ||
+    ('WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
     (window.console && (console.firebug || (console.exception && console.table))) ||
     // is firefox >= v31?

--- a/browser.js
+++ b/browser.js
@@ -44,9 +44,14 @@ exports.colors = [
  * TODO: add a `localStorage` variable to explicitly enable/disable colors
  */
 
+var isBrowser = typeof window != "undefined";
+var isWebWorker = !isBrowser && typeof DedicatedWorkerGlobalScope != "undefined";
+var isSharedWorker = !isBrowser && typeof SharedWorkerGlobalScope != "undefined";
+var isServiceWorker = !isBrowser && typeof ServiceWorkerGlobalScope != "undefined";
+
 function useColors() {
   // is webkit? http://stackoverflow.com/a/16459606/376773
-  return typeof ServiceWorkerGlobalScope == "undefined" && (
+  return isBrowser && (
     ('WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
     (window.console && (console.firebug || (console.exception && console.table))) ||


### PR DESCRIPTION
When bundling `debug` using `browserify` the browser version is used, and the `useColors` check crashes when in a ServiceWorker, because `document`, `window` and `navigator` are all `undefined`.
