### PR TITLE
Add bower.json to properly support bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "visionmedia/debug",
+  "main": "dist/debug.js",
+  "version": "2.0.0",
+  "homepage": "https://github.com/visionmedia/debug",
+  "authors": [
+    "TJ Holowaychuk <tj@vision-media.ca>"
+  ],
+  "description": "visionmedia/debug",
+  "moduleType": [
+    "amd",
+    "es6",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "visionmedia",
+    "debug"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
It would be nice to be able to install and use debug through bower directly from source repository.

To make it available in bower it would have to registered and ideally a new release would be created (to enable proper install by `bower install visionmedia/debug --save`)
