### PR TITLE
add support for chrome apps

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -18,7 +18,7 @@ exports.useColors = useColors;
 
 var storage;
 
-if (chrome && chrome.storage)
+if (typeof chrome !== 'undefined' && typeof chrome.storage !== 'undefined')
   storage = chrome.storage.local;
 else
   storage = window.localStorage;


### PR DESCRIPTION
In a chrome app, it appears the following error:

window.localStorage is not available in packaged apps. Use chrome.storage.local instead.
