### PR TITLE
Fix debug.disable()

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -157,7 +157,7 @@ function enable(namespaces) {
  */
 
 function disable() {
-  exports.enable('');
+  exports.names = [];
 }
 
 /**


### PR DESCRIPTION
Addresses issue #150

`exports.disable()` now resets the array `exports.names` to actually disable future debug instances.
