### PR TITLE
Introducing "dynamic mode" allowing enable/disable on the fly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 dist:
 	@mkdir -p $@
 
-dist/debug.js: node_modules browser.js debug.js dist
+dist/debug.js: node_modules browser.js debug.js able.js | dist
 	@$(BROWSERIFY) \
 		--standalone debug \
 		. > $@

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BIN := $(THIS_DIR)/node_modules/.bin
 NODE ?= $(shell which node)
 NPM ?= $(NODE) $(shell which npm)
 BROWSERIFY ?= $(NODE) $(BIN)/browserify
+MOCHA ?= $(NODE) $(BIN)/_mocha
 
 all: dist/debug.js
 
@@ -30,4 +31,7 @@ node_modules: package.json
 	@NODE_ENV= $(NPM) install
 	@touch node_modules
 
-.PHONY: all install clean
+test:
+	@$(MOCHA) -R dot
+
+.PHONY: all install clean test

--- a/able.js
+++ b/able.js
@@ -68,6 +68,9 @@ exports.parse = function (str) {
  */
 
 exports.enable = function (ns) {
+  // special case, empty the current list and allow it to append
+  if ('*' == ns) exports.clear();
+
   prune(disabled, ns);
   if (find(enabled, ns) > -1) return;
 
@@ -84,6 +87,9 @@ exports.enable = function (ns) {
  */
 
 exports.disable = function (ns) {
+  // special case, empty the current list (since default is to allow nothing)
+  if ('*' == ns) return exports.clear();
+
   prune(enabled, ns);
   if (find(disabled, ns) > -1) return;
 

--- a/able.js
+++ b/able.js
@@ -53,11 +53,9 @@ exports.stringify = function () {
  */
 
 exports.parse = function (str) {
-  if (!str) return;
-  str.split(/[\s,]+/).forEach(function (ns) {
-    if (!ns) return;
-    else if ('-' == ns[0]) exports.disable(ns.slice(1));
-    else                   exports.enable(ns);
+  if (!str) return [];
+  return (str || '').trim().split(/[\s,]+/).filter(function (item) {
+    return !!item;
   });
 };
 

--- a/able.js
+++ b/able.js
@@ -1,0 +1,143 @@
+/**
+ * in-memory cache
+ */
+
+var enabled = [];
+var disabled = [];
+
+/**
+ * Checks if the specified `ns` is enabled.
+ *
+ * @param {String} ns  Wildcards are not supported here
+ * @returns {Boolean}
+ */
+
+exports.enabled = function (ns) {
+  if (find(disabled, ns, true) > -1) return false;
+  if (find(enabled, ns, true) > -1) return true;
+  return false;
+};
+
+/**
+ * Destroys the lists of enabled/disabled. (primarilly for testing purposes)
+ */
+
+exports.clear = function () {
+  disabled.length = enabled.length = 0; // truncates w/o destroying
+};
+
+/**
+ * Outputs the list of enable/disabled in a single string.
+ *
+ * @returns {String}
+ */
+
+exports.stringify = function () {
+  var e = enabled.map(function (item) {
+    return item.string;
+  });
+
+  var d = disabled.map(function (item) {
+    return '-' + item.string;
+  });
+
+  return e.concat(d).join(',');
+};
+
+/**
+ * Parses a list and enables/disables accordingly.
+ *
+ * This list can either be passed from the user directly, or from .stringify()
+ *
+ * @param {String} str
+ */
+
+exports.parse = function (str) {
+  str.split(/[\s,]+/).forEach(function (ns) {
+    if (!ns) return;
+    else if ('-' == ns[0]) exports.disable(ns.slice(1));
+    else                   exports.enable(ns);
+  });
+};
+
+/**
+ * Enables the specified `ns`.
+ *
+ * @param {String} ns
+ */
+
+exports.enable = function (ns) {
+  prune(disabled, ns);
+  if (find(enabled, ns) > -1) return;
+
+  enabled.push({
+    string: ns,
+    regex: regex(ns)
+  });
+};
+
+/**
+ * Disables the specified `ns`.
+ *
+ * @param {String} ns
+ */
+
+exports.disable = function (ns) {
+  prune(enabled, ns);
+  if (find(disabled, ns) > -1) return;
+
+  disabled.push({
+    string: ns,
+    regex: regex(ns)
+  });
+};
+
+/**
+ * Searches for the given `ns` in the `arr`.
+ *
+ * By default, it only matches on the raw string, but if `regex` is set, it will
+ * match via the `RegExp` instead.
+ *
+ * Returns the index of the match, or -1 if not found.
+ *
+ * @param {Array} arr
+ * @param {String} ns
+ * @param {Boolean} [regex]
+ * @returns {Number}
+ */
+
+function find(arr, ns, regex) {
+  var ret = -1;
+  arr.some(function (item, x) {
+    if (regex ? item.regex.test(ns) : ns === item.string) {
+      ret = x;
+      return true;
+    }
+  });
+  return ret;
+}
+
+/**
+ * Wraps around `find(...)`, but also removes the found item.
+ *
+ * @param {Array} arr
+ * @param {String} ns
+ * @param {Boolean} [regex]
+ */
+
+function prune(arr, ns, regex) {
+  var x = find(arr, ns, regex);
+  if (x > -1) arr.splice(x, 1);
+}
+
+/**
+ * Converts a raw `ns` into a `RegExp`.
+ *
+ * @param {String} ns
+ * @returns {RegExp}
+ */
+
+function regex(ns) {
+  var pattern = ns.replace(/\*/g, '.*?');
+  return new RegExp('^' + pattern + '$');
+}

--- a/able.js
+++ b/able.js
@@ -53,6 +53,7 @@ exports.stringify = function () {
  */
 
 exports.parse = function (str) {
+  if (!str) return;
   str.split(/[\s,]+/).forEach(function (ns) {
     if (!ns) return;
     else if ('-' == ns[0]) exports.disable(ns.slice(1));

--- a/browser.js
+++ b/browser.js
@@ -13,34 +13,6 @@ exports.load = load;
 exports.useColors = useColors;
 
 /**
- * Enabled/disabled lists management.
- */
-
-var able = require('./able');
-
-/**
- * Wrapped enable that saves after list modified.
- *
- * @param {String} ns
- */
-
-exports.enable = function (ns) {
-  able.enable(ns);
-  save();
-};
-
-/**
- * Wrapped disable that saves after list modified.
- *
- * @param {String} ns
- */
-
-exports.disable = function (ns) {
-  able.disable(ns);
-  save();
-};
-
-/**
  * Colors.
  */
 
@@ -174,4 +146,4 @@ function load() {
  * Enable namespaces listed in `localStorage.debug` initially.
  */
 
-able.parse(load());
+exports.enable(load());

--- a/browser.js
+++ b/browser.js
@@ -13,6 +13,34 @@ exports.load = load;
 exports.useColors = useColors;
 
 /**
+ * Enabled/disabled lists management.
+ */
+
+var able = require('./able');
+
+/**
+ * Wrapped enable that saves after list modified.
+ *
+ * @param {String} ns
+ */
+
+exports.enable = function (ns) {
+  able.enable(ns);
+  save();
+};
+
+/**
+ * Wrapped disable that saves after list modified.
+ *
+ * @param {String} ns
+ */
+
+exports.disable = function (ns) {
+  able.disable(ns);
+  save();
+};
+
+/**
  * Colors.
  */
 
@@ -117,7 +145,7 @@ function log() {
 
 function save() {
   try {
-    var namespaces = exports.stringify();
+    var namespaces = able.stringify();
 
     if (null == namespaces) {
       localStorage.removeItem('debug');
@@ -146,4 +174,4 @@ function load() {
  * Enable namespaces listed in `localStorage.debug` initially.
  */
 
-exports.parse(load());
+able.parse(load());

--- a/browser.js
+++ b/browser.js
@@ -115,8 +115,10 @@ function log() {
  * @api private
  */
 
-function save(namespaces) {
+function save() {
   try {
+    var namespaces = exports.stringify();
+
     if (null == namespaces) {
       localStorage.removeItem('debug');
     } else {
@@ -144,4 +146,4 @@ function load() {
  * Enable namespaces listed in `localStorage.debug` initially.
  */
 
-exports.enable(load());
+exports.parse(load());

--- a/component.json
+++ b/component.json
@@ -11,7 +11,8 @@
   "main": "browser.js",
   "scripts": [
     "browser.js",
-    "debug.js"
+    "debug.js",
+    "able.js"
   ],
   "dependencies": {
     "guille/ms.js": "0.6.1"

--- a/debug.js
+++ b/debug.js
@@ -1,5 +1,11 @@
 
 /**
+ * Enabled/disabled status management
+ */
+
+var able = require('./able');
+
+/**
  * This is the common logic for both the Node.js and web browser
  * implementations of `debug()`.
  *
@@ -10,11 +16,10 @@ exports = module.exports = debug;
 exports.coerce = coerce;
 exports.humanize = require('ms');
 exports.dynamic = dynamic;
-
-var able = require('./able');
+exports.enable = enable;
+exports.disable = disable;
 exports.enabled = able.enabled;
-exports.enable = able.enable;
-exports.disable = able.disable;
+
 
 /**
  * Map of special "%n" handling functions, for the debug "format" argument.
@@ -157,4 +162,34 @@ function coerce(val) {
 
 function dynamic(flag) {
   isDynamic = !!flag;
+}
+
+/**
+ * Enables a string of namespaces (disables those with hyphen prefixes)
+ *
+ * @param {String} namespaces
+ */
+
+function enable(namespaces) {
+  able.parse(namespaces).forEach(function (ns) {
+    if ('-' == ns[0]) able.disable(ns.slice(1));
+    else              able.enable(ns);
+  });
+
+  exports.save();
+}
+
+/**
+ * Disables a string of namespaces (ignores hyphen prefixs if found)
+ *
+ * @param {String} namespaces
+ */
+
+function disable(namespaces) {
+  able.parse(namespaces).forEach(function (ns) {
+    if ('-' == ns[0]) ns = ns.slice(1);
+    able.disable(ns);
+  });
+
+  exports.save();
 }

--- a/debug.js
+++ b/debug.js
@@ -161,6 +161,7 @@ function coerce(val) {
  */
 
 function dynamic(flag) {
+  if (0 == arguments.length) return isDynamic;
   isDynamic = !!flag;
 }
 

--- a/debug.js
+++ b/debug.js
@@ -8,17 +8,13 @@
 
 exports = module.exports = debug;
 exports.coerce = coerce;
-exports.disable = disable;
-exports.enable = enable;
-exports.enabled = enabled;
 exports.humanize = require('ms');
+exports.dynamic = dynamic;
 
-/**
- * The currently active debug mode names, and names to skip.
- */
-
-exports.names = [];
-exports.skips = [];
+var able = require('./able');
+exports.enabled = able.enabled;
+exports.enable = able.enable;
+exports.disable = able.disable;
 
 /**
  * Map of special "%n" handling functions, for the debug "format" argument.
@@ -27,6 +23,12 @@ exports.skips = [];
  */
 
 exports.formatters = {};
+
+/**
+ * Flag for dynamic status.
+ */
+
+var isDynamic = false;
 
 /**
  * Previously assigned color.
@@ -117,70 +119,20 @@ function debug(namespace) {
     logFn.apply(self, args);
   }
   enabled.enabled = true;
+  enabled.namespace = namespace;
 
-  var fn = exports.enabled(namespace) ? enabled : disabled;
-
-  fn.namespace = namespace;
-
-  return fn;
-}
-
-/**
- * Enables a debug mode by namespaces. This can include modes
- * separated by a colon and wildcards.
- *
- * @param {String} namespaces
- * @api public
- */
-
-function enable(namespaces) {
-  exports.save(namespaces);
-
-  var split = (namespaces || '').split(/[\s,]+/);
-  var len = split.length;
-
-  for (var i = 0; i < len; i++) {
-    if (!split[i]) continue; // ignore empty strings
-    namespaces = split[i].replace(/\*/g, '.*?');
-    if (namespaces[0] === '-') {
-      exports.skips.push(new RegExp('^' + namespaces.substr(1) + '$'));
-    } else {
-      exports.names.push(new RegExp('^' + namespaces + '$'));
-    }
+  function dynamic() {
+    if (!exports.enabled(namespace)) return disabled();
+    return enabled.apply(enabled, arguments);
   }
-}
+  dynamic.namespace = namespace;
 
-/**
- * Disable debug output.
- *
- * @api public
- */
-
-function disable() {
-  exports.enable('');
-}
-
-/**
- * Returns true if the given mode name is enabled, false otherwise.
- *
- * @param {String} name
- * @return {Boolean}
- * @api public
- */
-
-function enabled(name) {
-  var i, len;
-  for (i = 0, len = exports.skips.length; i < len; i++) {
-    if (exports.skips[i].test(name)) {
-      return false;
-    }
+  function fn() {
+    if (isDynamic) return dynamic;
+    return exports.enabled(namespace) ? enabled : disabled;
   }
-  for (i = 0, len = exports.names.length; i < len; i++) {
-    if (exports.names[i].test(name)) {
-      return true;
-    }
-  }
-  return false;
+
+  return fn();
 }
 
 /**
@@ -194,4 +146,15 @@ function enabled(name) {
 function coerce(val) {
   if (val instanceof Error) return val.stack || val.message;
   return val;
+}
+
+/**
+ * Get/set the dynamic flag
+ *
+ * @param {Boolean} [flag]
+ * @returns {Boolean}
+ */
+
+function dynamic(flag) {
+  isDynamic = !!flag;
 }

--- a/example/dynamic/app.js
+++ b/example/dynamic/app.js
@@ -1,0 +1,43 @@
+// NOTE - run using: DEBUG=example DEBUG_DYN=1 node app.js
+
+var debug = require('../..')
+  , express = require('express')
+  , bodyParser = require('body-parser')
+  , app = express()
+  , name = 'example';
+
+var log = debug(name)
+log('booting example app');
+
+app.use(bodyParser.urlencoded({ extended: false }));
+
+app.use(function (req, res, next) {
+  log(req.method + ' ' + req.url);
+  next();
+});
+
+app.get('/', function (req, res) {
+  log('sending form');
+  res.sendFile(__dirname + '/index.html');
+});
+
+app.post('/debug', function (req, res) {
+  if ('enable' in req.body) {
+    log('enabling');
+    debug.enable(name);
+  } else {
+    log('disabling');
+    debug.disable(name);
+  }
+  res.redirect('/');
+});
+
+app.post('/disable', function (req, res) {
+  log('disabling');
+  debug.disable(name);
+  res.redirect('/');
+});
+
+app.listen(3000, function () {
+  log('listening');
+});

--- a/example/dynamic/index.html
+++ b/example/dynamic/index.html
@@ -1,0 +1,4 @@
+<form method="post" action="/debug">
+  <button name="enable" type="submit">Enable</button>
+  <button name="disable" type="submit">Disable</button>
+</form>

--- a/node.js
+++ b/node.js
@@ -20,6 +20,12 @@ exports.load = load;
 exports.useColors = useColors;
 
 /**
+ * Enabled/disabled lists management.
+ */
+
+var able = require('./able');
+
+/**
  * Colors.
  */
 
@@ -113,7 +119,7 @@ function log() {
  */
 
 function save() {
-  var namespaces = exports.stringify();
+  var namespaces = able.stringify();
 
   if (null == namespaces) {
     // If you set a process.env field to null or undefined, it gets cast to the
@@ -215,4 +221,4 @@ if (process.env.DEBUG_DYN) {
  * Enable namespaces listed in `process.env.DEBUG` initially.
  */
 
-exports.parse(load());
+able.parse(load());

--- a/node.js
+++ b/node.js
@@ -221,4 +221,4 @@ if (process.env.DEBUG_DYN) {
  * Enable namespaces listed in `process.env.DEBUG` initially.
  */
 
-able.parse(load());
+exports.enable(load());

--- a/node.js
+++ b/node.js
@@ -109,11 +109,12 @@ function log() {
 /**
  * Save `namespaces`.
  *
- * @param {String} namespaces
  * @api private
  */
 
-function save(namespaces) {
+function save() {
+  var namespaces = exports.stringify();
+
   if (null == namespaces) {
     // If you set a process.env field to null or undefined, it gets cast to the
     // string 'null' or 'undefined'. Just delete instead.
@@ -203,7 +204,15 @@ function createWritableStdioStream (fd) {
 }
 
 /**
+ * Enable dynamic mode when `process.env.DEBUG_DYN` is set to `1`
+ */
+
+if (process.env.DEBUG_DYN) {
+  exports.dynamic(process.env.DEBUG_DYN == 1);
+}
+
+/**
  * Enable namespaces listed in `process.env.DEBUG` initially.
  */
 
-exports.enable(load());
+exports.parse(load());

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "ms": "0.6.2"
   },
   "devDependencies": {
+    "body-parser": "^1.9.2",
     "browserify": "6.1.0",
-    "mocha": "*"
+    "express": "^4.10.2",
+    "mocha": "^2.0.1"
   },
   "main": "./node.js",
   "browser": "./browser.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "component": {
     "scripts": {
       "debug/index.js": "browser.js",
-      "debug/debug.js": "debug.js"
+      "debug/debug.js": "debug.js",
+      "debug/able.js": "able.js"
     }
   }
 }

--- a/test/able.js
+++ b/test/able.js
@@ -1,0 +1,116 @@
+var able = require('../able');
+var assert = require('assert');
+
+describe('enable/disable feature', function () {
+  afterEach(able.clear);
+
+  describe('.enabled(ns)', function () {
+    it('should return booleans', function () {
+      assert.strictEqual(able.enabled('foo'), false);
+      able.enable('*');
+      assert.strictEqual(able.enabled('foo'), true);
+    });
+
+    it('should not allow anything by default', function () {
+      assert(!able.enabled('express'));
+      assert(!able.enabled('connect'));
+    });
+
+    it('should work with basic strings', function () {
+      able.enable('express');
+      assert(able.enabled('express'));
+      assert(!able.enabled('connect'));
+    });
+
+    it('should work with wildcards', function () {
+      able.enable('express*');
+      assert(able.enabled('express'));
+      assert(able.enabled('express:router'));
+      assert(!able.enabled('connect'));
+    });
+  });
+
+  describe('.stringify()', function () {
+    it('should return a string', function () {
+      assert.equal(typeof able.stringify(), 'string');
+    });
+
+    it('should return a comma-separated list of enabled namespaces', function () {
+      able.enable('a');
+      able.enable('b');
+      able.enable('c');
+      assert.equal(able.stringify(), 'a,b,c');
+    });
+
+    it('should prefix disabled namespaces with a hyphen', function () {
+      able.enable('*');
+      able.disable('express');
+      able.disable('connect');
+      assert.equal(able.stringify(), '*,-express,-connect');
+    });
+  });
+
+  describe('.parse(str)', function () {
+    it('should respect either white-space or comma separated values', function () {
+      able.parse('a,b c  , d    e');
+      assert(able.enabled('a'));
+      assert(able.enabled('b'));
+      assert(able.enabled('c'));
+      assert(able.enabled('d'));
+      assert(able.enabled('e'));
+    });
+
+    it('should treat hyphen prefixs as disabled', function () {
+      able.enable('*');
+      able.parse('-b,-c,  -d  -e');
+      assert(able.enabled('a'));
+      assert(!able.enabled('b'));
+      assert(!able.enabled('c'));
+      assert(!able.enabled('d'));
+      assert(!able.enabled('e'));
+      assert(able.enabled('f'));
+    });
+  });
+
+  describe('.enable(ns)', function () {
+    it('should enable the specified namespace', function () {
+      able.enable('express');
+      assert(able.enabled('express'));
+    });
+
+    it('should enable the specified wildcard namespace', function () {
+      able.enable('express*');
+      assert(able.enabled('express:router'));
+    });
+
+    it('should work correctly even when previously disabled', function () {
+      able.enable('*');
+      assert(able.enabled('express'));
+      able.disable('express');
+      assert(!able.enabled('express'));
+      able.enable('express');
+      assert(able.enabled('express'));
+    });
+  });
+
+  describe('.disable(ns)', function () {
+    it('should disable the specified namespace', function () {
+      able.enable('*');
+      able.disable('express');
+      assert(!able.enabled('express'));
+    });
+
+    it('should disable the specified wildcard namespace', function () {
+      able.enable('*');
+      able.disable('express*');
+      assert(!able.enabled('express:router'));
+    });
+
+    it('should work correctly even when previously enabled', function () {
+      able.enable('express');
+      assert(able.enabled('express'));
+      able.disable('express');
+      assert(!able.enabled('express'));
+    });
+  });
+});


### PR DESCRIPTION
So, apologies in advance for the extra large PR. This is a feature I think that would be really useful, and I intend to solve several issues in one fell swoop. I'm also wide open to feedback on this, just let me know what you think!

Currently, the list of enabled/disabled namespaces is determined during init. Changing the list via `.enable()` and `.disable()` have no effect once a function has already been returned by `debug()`. (#150) This decision allows some optimization at a low-level, which is a good thing. (and why the feature I have here is opt-in)

For servers, it could be useful to turn on and off debugging for various features at will, without needing to restart the server to do so. This is what I had in mind while developing this feature, so you'll find a new example demonstrating the use-case. As an aside, I did not implement this feature for browsers yet, since it seems more like a server feature, but it would not be terribly complex to make them more consistent.

In dynamic mode, rather than returning a working `enabled` or `disabled` function, it returns a thin wrapper that checks `.enabled(namespace)` when invoked. This allows dynamically turning on and off various debug instances at will.

To enable dynamic mode, you can either use `DEBUG_DYN=1` or `debug.dynamic(true);`, but the former is arguably easier. (since it will ensure all debug instances are created in dynamic mode)

To facilitate a dynamically-changing list of enabled/disabled namespaces, I needed to overhaul the underlying system. I've created `able.js`, (haha, terrible name, I'm open to alternatives!) along with a mocha test suite. (gives us a good start toward #104) It's a singleton lib that is a simple handler for things like `.enable()`, `.disable()`, `.enabled()` and a bit more. In addition, it includes a `.stringify()` method that generates a list like described in #19. (and a corresponding `.parse()` method for parsing user input)

All the fanfare around a distinct "dynamic mode" adds some complexity to the code, but this allows the already-optimized version to remain. If you guys are open to it, I'd like to investigate making this the default behavior, and probably benchmarking to see if there's a noticeable difference in performance.

I tried to be very careful with my changes here, although it was unfortunately difficult without any tests in place. I've tried out all the examples, and they appear to function as designed. Not only that, but I made a special effort to not change the current public API. I also tried to follow the existing code conventions, correct me where I've deviated.
## tl;dr
- "dynamic mode" allows changing enabled/disabled debugs on the fly (enabled via `DEBUG_DYN=1` or `debug.dynamic(true)`
- `able.js` is the file now responsible for managing the list of enabled/disabled namespaces (it also has tests)
- currently this is opt-in, but I would like to hear thoughts on making it the default behavior
- was careful not to change the public API, and examples were tested thoroughly to make sure it still works (but without proper tests, that was harder than it needed to be)
