### PR TITLE
Update debug.js

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -121,6 +121,8 @@ function debug(namespace) {
   var fn = exports.enabled(namespace) ? enabled : disabled;
 
   fn.namespace = namespace;
+  fn.enable = enable;
+  fn.disable = disable;
 
   return fn;
 }


### PR DESCRIPTION
this change would allow the use of `enable` and `disable` when debug is instantiated/initialized in the standard `var debug = require('debug')('my_scope');` form. today if during runtime i want to enable debugging (due to an option on the command-line or by detecting the global debugging state in v8 or chrome via `(typeof v8debug === 'object')` i get an obscure error `enabled() is not defined` because this format returns just the namespace object with the single debug function unlike the require which returns the whole exports object with many functions. if i say `debug.enable('my_scope');` and I have to use `require('debug').enable('my_scope');`. in a way it would be ideal if the `require('debug')('my_scope')` form returned the compleat set of `exports` functions and not just enable/disable.
