### PR TITLE
Add %j and %J formatters for node.js logger.

### DIFF
--- a/node.js
+++ b/node.js
@@ -73,6 +73,14 @@ exports.formatters.o = function(v) {
     .replace(/\s*\n\s*/g, ' ');
 };
 
+exports.formatters.j = function(v) {
+  return JSON.stringify(v, undefined, 2);
+};
+
+exports.formatters.J = function(v) {
+  return JSON.stringify(v);
+};
+
 /**
  * Adds ANSI color escape codes if enabled.
  *


### PR DESCRIPTION
- %j — pretty-prints JSON in a node console
- %J — deeply inspects JSON without pretty-printing
