### PR TITLE
browser: Fixed that no logs output on IE8/9

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -103,9 +103,8 @@ function formatArgs() {
 function log() {
   // This hackery is required for IE8,
   // where the `console.log` function doesn't have 'apply'
-  return 'object' == typeof console
-    && 'function' == typeof console.log
-    || 'object' == typeof console.log // IE 8-9 reports console methods as objects when using the typeof operator.
+  return console
+    && console.log
     && Function.prototype.apply.call(console.log, console, arguments);
 }
 


### PR DESCRIPTION
IE 8/9 reports console methods as objects when using the typeof operator.
https://web.archive.org/web/20111123190115/http://whattheheadsaid.com/2011/04/internet-explorer-9s-problematic-console-object

Closes #148.
