### PR TITLE
changed bower package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
-  "name": "visionmedia/debug",
+  "name": "visionmedia-debug",
   "main": "dist/debug.js",
   "version": "2.1.1",
   "homepage": "https://github.com/visionmedia/debug",
   "authors": [
     "TJ Holowaychuk <tj@vision-media.ca>"
   ],
-  "description": "visionmedia/debug",
+  "description": "visionmedia-debug",
   "moduleType": [
     "amd",
     "es6",


### PR DESCRIPTION
Slashes are not allowed in bower component name (https://github.com/bower/bower.json-spec).

Slashes also cause practical problems (at least on OSX). For example, bower installs component files without any problems, but on update ends up with error saying that package is not installed.