### PR TITLE
Catch JSON stringily errors.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -59,7 +59,11 @@ function useColors() {
  */
 
 exports.formatters.j = function(v) {
-  return JSON.stringify(v);
+  try {
+    return JSON.stringify(v);
+  }catch( err){
+    return '[UnexpectedJSONParseError]: ' + err.message;
+  }
 };
 
 

--- a/dist/debug.js
+++ b/dist/debug.js
@@ -384,7 +384,11 @@ function useColors() {
  */
 
 exports.formatters.j = function(v) {
-  return JSON.stringify(v);
+  try {
+    return JSON.stringify(v);
+  }catch( err){
+    return '[UnexpectedJSONParseError]: ' + err.message;
+  }
 };
 
 


### PR DESCRIPTION
There is a chance that there may be circular references in the Object which will cause the debug message to throw an exception. If the exception is not handled on the application level this will cause node to crash. As a debug library, errors in here should not have such a serious impact on the application.
