### PR TITLE
Allow debug to be used within a web worker thread

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -39,9 +39,9 @@ exports.colors = [
 
 function useColors() {
   // is webkit? http://stackoverflow.com/a/16459606/376773
-  return ('WebkitAppearance' in document.documentElement.style) ||
+  return (typeof document !== 'undefined' && 'WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
-    (window.console && (console.firebug || (console.exception && console.table))) ||
+    (typeof window !== 'undefined' && window.console && (console.firebug || (console.exception && console.table))) ||
     // is firefox >= v31?
     // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
     (navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31);


### PR DESCRIPTION
When trying to use the debug module within the browser in the context of a web worker, document and window aren't available, therefore it will throw an exception. Checking for document and window before using colors seems to be the only place where these checks are performed before initialization. 