### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "visionmedia-debug",
   "main": "dist/debug.js",
-  "version": "2.2.0",
   "homepage": "https://github.com/visionmedia/debug",
   "authors": [
     "TJ Holowaychuk <tj@vision-media.ca>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property