### PR TITLE
Add optional dynamic debug instances (react on enable() and disable() once created)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,22 @@ Then, run the program to be debugged as usual.
 
   You can also exclude specific debuggers by prefixing them with a "-" character.  For example, `DEBUG=*,-connect:*` would include all debuggers except those starting with "connect:".
 
+## enable() and disable() functions
+
+  The module exports a `enable(namespaces)` function that updates the enabled namespaces, and `disable()` function that disables the logging. Note however that those functions just work on future created debug instances (unless they were dynamic instances).
+
+## Dynamic debug instances
+
+  Dynamic debug instances are those whose behavior (whether they are printed or not) is updated in **runtime** for every call to the module exported `enable()` or `disabled()` methods (see above).
+
+  Dynamic debug instances are created by passing `true` as second argument to the module exported function:
+
+```js
+var dyndebug = require('debug')('myApp', true);
+```
+
+  *IMPORTANT:* Dynamic debug instances are stored within the module so they may cause a memory leak technically (if instances are created in runtime rather than statically at the script start). To avoid that, call the `release()` method on them. Once `release()` is called the instance is no longer dynamic.
+
 ## Browser support
 
   Debug works in the browser as well, currently persisted by `localStorage`. Consider the situation shown below where you have `worker:a` and `worker:b`, and wish to debug both. Somewhere in the code on your page, include:

--- a/example/dynamic.js
+++ b/example/dynamic.js
@@ -1,0 +1,24 @@
+process.env.DEBUG = '*';
+
+
+var debug = require('../');
+
+
+var dyndebug1 = debug('dyndebug1', true);
+dyndebug1('OK: should show dyndebug1');
+
+debug.disable();
+console.log('DEBUG should be undefined, and it is:', process.env.DEBUG);
+dyndebug1('ERROR: should not show dyndebug1');
+
+var dyndebug2 = debug('dyndebug2', true);
+dyndebug2('ERROR: should not show dyndebug2');
+
+debug.enable('dyndebug1');
+console.log('DEBUG should be dyndebug1, and it is:', process.env.DEBUG);
+dyndebug1('OK: should show dyndebug1');
+
+debug.enable('dyndebug2');
+console.log('DEBUG should be dyndebug2, and it is:', process.env.DEBUG);
+dyndebug1('ERROR: should not show dyndebug1');
+dyndebug2('OK: should show dyndebug2');


### PR DESCRIPTION
First of all: this PR is 100% **compliant** with the current design and adds **zero** overhead to it. This is, no changes must be done in apps and libraries already using the _debug_ module, and the performance is the same as before.

This PR adds "dynamic debug instances" which are created by passing `true` as the second parameter to the module exported function:

``` js
var debug = require('debug');
var applog = debug('myApp', true);
```

Those instances **do properly** react if `debug.enable(xxxx)` or `debug.disable()` is called after they are created.

An [usage example](https://github.com/ibc/debug/blob/master/example/dynamic.js) is provided in the _example/_ folder.

The PR also resets `exports.names` and `exports.skips` when `enable()` or `disable()` is called (rationale [here](https://github.com/visionmedia/debug/issues/150#issuecomment-60466454)).

Related issues:
- https://github.com/visionmedia/debug/issues/150
- https://github.com/visionmedia/debug/issues/154
