### PR TITLE
Disable colors when the browser is PhantomJS.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -33,11 +33,17 @@ exports.colors = [
  * Currently only WebKit-based Web Inspectors, Firefox >= v31,
  * and the Firebug extension (any Firefox version) are known
  * to support "%c" CSS customizations.
+ * PhantomJS is an exception: it is a WebKit-based browser that
+ * does not support "%c".
  *
  * TODO: add a `localStorage` variable to explicitly enable/disable colors
  */
 
 function useColors() {
+  // is phantomjs?
+  if (navigator.appVersion.toLowerCase().match(/.*phantomjs.*/)) {
+    return false;
+  }
   // is webkit? http://stackoverflow.com/a/16459606/376773
   return ('WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773


### PR DESCRIPTION
Because PhantomJS is WebKit, `debug` thinks it supports colors, but PhantomJS logs to the terminal and the output comes out like this:

```
 '%cManager %cstyle%c +20ms', 'color: lightseagreen', 'color: inherit', 'color: lightseagreen'
```

After this PR, colors are disabled and the output looks OK:

```
Manager style +20ms
```

If you want any changes to this PR before merging just let me know! 😸
