### PR TITLE
expose debug as default export

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -6,7 +6,7 @@
  * Expose `debug()` as the module.
  */
 
-exports = module.exports = debug;
+exports = module.exports = debug.debug = debug;
 exports.coerce = coerce;
 exports.disable = disable;
 exports.enable = enable;


### PR DESCRIPTION
+ Similar to [tj/co](https://github.com/tj/co/blob/master/index.js#L12)
+ Allow to re-export debug from another module in ES6

Without this fix, it is troublesome to re-export debug from a module. Basically, the following will not compile / `debug` will not be correctly exported as it should:

```js
// my utilities
export myLog () {}
export * from "debug" // just re-export debug 
...
```