### PR TITLE
move ms to the last place

### DIFF
--- a/node.js
+++ b/node.js
@@ -80,17 +80,21 @@ exports.formatters.o = function(v) {
  */
 
 function formatArgs() {
-  var args = arguments;
+  var args = [];
+  var len = arguments.length;
   var useColors = this.useColors;
   var name = this.namespace;
+  for (var i = 0; i < len; i++) {
+    args.push(arguments[i]);
+  }
 
   if (useColors) {
     var c = this.color;
 
     args[0] = '  \u001b[3' + c + ';1m' + name + ' '
       + '\u001b[0m'
-      + args[0] + '\u001b[3' + c + 'm'
-      + ' +' + exports.humanize(this.diff) + '\u001b[0m';
+      + args[0];
+    args.push('\u001b[3' + c + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
   } else {
     args[0] = new Date().toUTCString()
       + ' ' + name + ' ' + args[0];


### PR DESCRIPTION
when you call debug with more than one param ms diff goes to the second place

```javascript
var debug = require('debug')('OK');
debug('awesome', 'debug', 'message');  
```
  before
```OK awesome +0ms debug message```
  
  after
 ```OK awesome debug message +0ms```
