### PR TITLE
browser-supports-log-styles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -10,7 +10,7 @@ exports.log = log;
 exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
-exports.useColors = useColors;
+exports.useColors = require('browser-supports-log-styles');
 exports.storage = 'undefined' != typeof chrome
                && 'undefined' != typeof chrome.storage
                   ? chrome.storage.local
@@ -28,24 +28,6 @@ exports.colors = [
   'darkorchid',
   'crimson'
 ];
-
-/**
- * Currently only WebKit-based Web Inspectors, Firefox >= v31,
- * and the Firebug extension (any Firefox version) are known
- * to support "%c" CSS customizations.
- *
- * TODO: add a `localStorage` variable to explicitly enable/disable colors
- */
-
-function useColors() {
-  // is webkit? http://stackoverflow.com/a/16459606/376773
-  return ('WebkitAppearance' in document.documentElement.style) ||
-    // is firebug? http://stackoverflow.com/a/398120/376773
-    (window.console && (console.firebug || (console.exception && console.table))) ||
-    // is firefox >= v31?
-    // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
-    (navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31);
-}
 
 /**
  * Map %j to `JSON.stringify()`, since no Web Inspectors do that by default.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "browser-supports-log-styles": "^1.1.1",
     "ms": "0.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I need a check if a browser supports console log styles in another library, so I created a tiny npm package [browser-supports-log-styles](https://www.npmjs.com/package/browser-supports-log-styles) for that, and thought you might want to use that as well, so we can keep that up-to-date together?

Let me know if you want any changes in that, it's your work after all, I don't mean to take any credit for it
