### PR TITLE
Check for web workers, fixes #240

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -38,6 +38,11 @@ exports.colors = [
  */
 
 function useColors() {
+  // check we aren't in a web worker
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  
   // is webkit? http://stackoverflow.com/a/16459606/376773
   return ('WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773


### PR DESCRIPTION
It should be sufficient to check for a global `window` object. If the user is bonkers and actually declares a global `window` inside of their web worker... then well, we can't help them. The alternative would be to check for all three of `window`, `document`, and `navigator`, which I think is excessive.
