### PR TITLE
handle regex special characters

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -141,7 +141,7 @@ function enable(namespaces) {
 
   for (var i = 0; i < len; i++) {
     if (!split[i]) continue; // ignore empty strings
-    namespaces = split[i].replace(/\*/g, '.*?');
+    namespaces = split[i].replace(/[\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*?');
     if (namespaces[0] === '-') {
       exports.skips.push(new RegExp('^' + namespaces.substr(1) + '$'));
     } else {


### PR DESCRIPTION
Currently, enabling namespaces which contain regex special characters leads to unexpected results.  Examples:

```js
var debug = require('debug');
debug.enable("abc[def],x.z,what?");

console.log(debug.enabled('abcf'));  // yields true, should be false
console.log(debug.enabled('abc[def]'));  // yields false, should be true

console.log(debug.enabled('xyz'));  // yields true, should be false

console.log(debug.enabled('what?'));  // yields false, should be true
console.log(debug.enabled('wha'));  // yields true, should be false

debug.enable("oops[");  // throws an error
```

This PR fixes that by escaping the regex special characters within the namespace strings (while still properly allowing `*` to be a wildcard).  The escape code is based on the proposed ES7 `RegEx.escape` polyfill found at https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js

Since this escaping only happens when `.enable()` is called and not when `.enabled()` is called or the log function is actually used, it should not negatively impact the performance of apps using this module.