### PR TITLE
Revert "npmignore: don't publish the `dist` dir"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@ test
 examples
 example
 *.sock
-dist


### PR DESCRIPTION
This reverts commit 43b0d51c21134e86014f0ba007dfdabc6b21a35e.

This fixes #242
