### PR TITLE
Print objects more clearly with more precise informations and avoid util.inspect

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -110,23 +110,25 @@ function debug(namespace) {
         });
 
         var stillNeedToParse = args[0].match(/%([a-z%])/g),
-            paramsToKeep = stillNeedToParse != void 0 ? stillNeedToParse.length : 0;
+            argsToKeep = 0;
         if (stillNeedToParse != void 0) {
             stillNeedToParse.forEach(function(d) {
-                if (d[1] === '%') {
-                    paramsToKeep--;
+                if (d[1] !== '%') {
+                    argsToKeep++;
                 }
             });
         }
 
-        for (var i = 1; i < args.length; i++) {
+        // console.log(argsToKeep, args.slice(1));
+        for (var i = 1 + argsToKeep; i < args.length; i++) {
             if (typeof args[i] !== 'object') {
                 args[0] += ' ' + args[i];
                 continue;
             }
             args[0] += '\n  ' + exports.formatters.o.call(self, args[i]);
         }
-        args = args.slice(0, args.length - paramsToKeep);
+        // console.log(argsToKeep, args.slice(1));
+        args = args.slice(0, 1 + argsToKeep);
 
         if ('function' === typeof exports.formatArgs) {
             args = exports.formatArgs.apply(self, args);

--- a/debug.js
+++ b/debug.js
@@ -1,4 +1,3 @@
-
 /**
  * This is the common logic for both the Node.js and web browser
  * implementations of `debug()`.
@@ -48,7 +47,7 @@ var prevTime;
  */
 
 function selectColor() {
-  return exports.colors[prevColor++ % exports.colors.length];
+    return exports.colors[prevColor++ % exports.colors.length];
 }
 
 /**
@@ -61,68 +60,73 @@ function selectColor() {
 
 function debug(namespace) {
 
-  // define the `disabled` version
-  function disabled() {
-  }
-  disabled.enabled = false;
+    // define the `disabled` version
+    function disabled() {}
+    disabled.enabled = false;
 
-  // define the `enabled` version
-  function enabled() {
+    // define the `enabled` version
+    function enabled() {
 
-    var self = enabled;
+        var self = enabled;
 
-    // set `diff` timestamp
-    var curr = +new Date();
-    var ms = curr - (prevTime || curr);
-    self.diff = ms;
-    self.prev = prevTime;
-    self.curr = curr;
-    prevTime = curr;
+        // set `diff` timestamp
+        var curr = +new Date();
+        var ms = curr - (prevTime || curr);
+        self.diff = ms;
+        self.prev = prevTime;
+        self.curr = curr;
+        prevTime = curr;
 
-    // add the `color` if not set
-    if (null == self.useColors) self.useColors = exports.useColors();
-    if (null == self.color && self.useColors) self.color = selectColor();
+        // add the `color` if not set
+        if (null == self.useColors) self.useColors = exports.useColors();
+        if (null == self.color && self.useColors) self.color = selectColor();
+        if (null == self.stylize) self.stylize = exports.stylize;
 
-    var args = Array.prototype.slice.call(arguments);
+        var args = Array.prototype.slice.call(arguments);
 
-    args[0] = exports.coerce(args[0]);
+        args[0] = exports.coerce(args[0]);
 
-    if ('string' !== typeof args[0]) {
-      // anything else let's inspect with %o
-      args = ['%o'].concat(args);
+        if ('string' !== typeof args[0]) {
+            // anything else let's inspect with %o
+            args = ['%o'].concat(args);
+        }
+
+        // apply any `formatters` transformations
+        var index = 0;
+        args[0] = args[0].replace(/%([a-z%])/g, function(match, format) {
+            // if we encounter an escaped % then don't increase the array index
+            if (match === '%') return match;
+            index++;
+            var formatter = exports.formatters[format];
+            if ('function' === typeof formatter) {
+                var val = args[index];
+                match = formatter.call(self, val);
+
+                // now we need to remove `args[index]` since it's inlined in the `format`
+                args.splice(index, 1);
+                index--;
+            }
+            return match;
+        });
+
+        for (var i = 1; i < args.length; i++) {
+            args[0] += ' ' + exports.formatters.o.call(self, args[i]);
+        }
+        args = args.slice(0, 1);
+
+        if ('function' === typeof exports.formatArgs) {
+            args = exports.formatArgs.apply(self, args);
+        }
+        var logFn = enabled.log || exports.log || console.log.bind(console);
+        logFn.apply(self, args);
     }
+    enabled.enabled = true;
 
-    // apply any `formatters` transformations
-    var index = 0;
-    args[0] = args[0].replace(/%([a-z%])/g, function(match, format) {
-      // if we encounter an escaped % then don't increase the array index
-      if (match === '%%') return match;
-      index++;
-      var formatter = exports.formatters[format];
-      if ('function' === typeof formatter) {
-        var val = args[index];
-        match = formatter.call(self, val);
+    var fn = exports.enabled(namespace) ? enabled : disabled;
 
-        // now we need to remove `args[index]` since it's inlined in the `format`
-        args.splice(index, 1);
-        index--;
-      }
-      return match;
-    });
+    fn.namespace = namespace;
 
-    if ('function' === typeof exports.formatArgs) {
-      args = exports.formatArgs.apply(self, args);
-    }
-    var logFn = enabled.log || exports.log || console.log.bind(console);
-    logFn.apply(self, args);
-  }
-  enabled.enabled = true;
-
-  var fn = exports.enabled(namespace) ? enabled : disabled;
-
-  fn.namespace = namespace;
-
-  return fn;
+    return fn;
 }
 
 /**
@@ -134,20 +138,20 @@ function debug(namespace) {
  */
 
 function enable(namespaces) {
-  exports.save(namespaces);
+    exports.save(namespaces);
 
-  var split = (namespaces || '').split(/[\s,]+/);
-  var len = split.length;
+    var split = (namespaces || '').split(/[\s,]+/);
+    var len = split.length;
 
-  for (var i = 0; i < len; i++) {
-    if (!split[i]) continue; // ignore empty strings
-    namespaces = split[i].replace(/\*/g, '.*?');
-    if (namespaces[0] === '-') {
-      exports.skips.push(new RegExp('^' + namespaces.substr(1) + '$'));
-    } else {
-      exports.names.push(new RegExp('^' + namespaces + '$'));
+    for (var i = 0; i < len; i++) {
+        if (!split[i]) continue; // ignore empty strings
+        namespaces = split[i].replace(/\*/g, '.*?');
+        if (namespaces[0] === '-') {
+            exports.skips.push(new RegExp('^' + namespaces.substr(1) + '$'));
+        } else {
+            exports.names.push(new RegExp('^' + namespaces + '$'));
+        }
     }
-  }
 }
 
 /**
@@ -157,7 +161,7 @@ function enable(namespaces) {
  */
 
 function disable() {
-  exports.enable('');
+    exports.enable('');
 }
 
 /**
@@ -169,18 +173,18 @@ function disable() {
  */
 
 function enabled(name) {
-  var i, len;
-  for (i = 0, len = exports.skips.length; i < len; i++) {
-    if (exports.skips[i].test(name)) {
-      return false;
+    var i, len;
+    for (i = 0, len = exports.skips.length; i < len; i++) {
+        if (exports.skips[i].test(name)) {
+            return false;
+        }
     }
-  }
-  for (i = 0, len = exports.names.length; i < len; i++) {
-    if (exports.names[i].test(name)) {
-      return true;
+    for (i = 0, len = exports.names.length; i < len; i++) {
+        if (exports.names[i].test(name)) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 /**
@@ -192,6 +196,6 @@ function enabled(name) {
  */
 
 function coerce(val) {
-  if (val instanceof Error) return val.stack || val.message;
-  return val;
+    if (val instanceof Error) return val.stack || val.message;
+    return val;
 }

--- a/debug.js
+++ b/debug.js
@@ -109,14 +109,24 @@ function debug(namespace) {
             return match;
         });
 
+        var stillNeedToParse = args[0].match(/%([a-z%])/g),
+            paramsToKeep = stillNeedToParse != void 0 ? stillNeedToParse.length : 0;
+        if (stillNeedToParse != void 0) {
+            stillNeedToParse.forEach(function(d) {
+                if (d[1] === '%') {
+                    paramsToKeep--;
+                }
+            });
+        }
+
         for (var i = 1; i < args.length; i++) {
             if (typeof args[i] !== 'object') {
                 args[0] += ' ' + args[i];
                 continue;
             }
-            args[0] += ' ' + exports.formatters.o.call(self, args[i]);
+            args[0] += '\n  ' + exports.formatters.o.call(self, args[i]);
         }
-        args = args.slice(0, 1);
+        args = args.slice(0, args.length - paramsToKeep);
 
         if ('function' === typeof exports.formatArgs) {
             args = exports.formatArgs.apply(self, args);

--- a/debug.js
+++ b/debug.js
@@ -110,6 +110,10 @@ function debug(namespace) {
         });
 
         for (var i = 1; i < args.length; i++) {
+            if (typeof args[i] !== 'object') {
+                args[0] += ' ' + args[i];
+                continue;
+            }
             args[0] += ' ' + exports.formatters.o.call(self, args[i]);
         }
         args = args.slice(0, 1);

--- a/node.js
+++ b/node.js
@@ -1,10 +1,11 @@
-
 /**
  * Module dependencies.
  */
 
-var tty = require('tty');
-var util = require('util');
+var tty = require('tty'),
+    util = require('util'),
+    colors = require('colors'),
+    moment = require('moment');
 
 /**
  * This is the Node.js implementation of `debug()`.
@@ -18,6 +19,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.stylize = stylize;
 
 /**
  * Colors.
@@ -34,23 +36,20 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 
 var fd = parseInt(process.env.DEBUG_FD, 10) || 2;
 var stream = 1 === fd ? process.stdout :
-             2 === fd ? process.stderr :
-             createWritableStdioStream(fd);
+    2 === fd ? process.stderr :
+    createWritableStdioStream(fd);
 
 /**
  * Is stdout a TTY? Colored output is enabled when `true`.
  */
 
 function useColors() {
-  var debugColors = (process.env.DEBUG_COLORS || '').trim().toLowerCase();
-  if (0 === debugColors.length) {
-    return tty.isatty(fd);
-  } else {
-    return '0' !== debugColors
-        && 'no' !== debugColors
-        && 'false' !== debugColors
-        && 'disabled' !== debugColors;
-  }
+    var debugColors = (process.env.DEBUG_COLORS || '').trim().toLowerCase();
+    if (0 === debugColors.length) {
+        return tty.isatty(fd);
+    } else {
+        return '0' !== debugColors && 'no' !== debugColors && 'false' !== debugColors && 'disabled' !== debugColors;
+    }
 }
 
 /**
@@ -58,19 +57,91 @@ function useColors() {
  */
 
 var inspect = (4 === util.inspect.length ?
-  // node <= 0.8.x
-  function (v, colors) {
-    return util.inspect(v, void 0, void 0, colors);
-  } :
-  // node > 0.8.x
-  function (v, colors) {
-    return util.inspect(v, { colors: colors });
-  }
+    // node <= 0.8.x
+    function(v, colors) {
+        return util.inspect(v, void 0, void 0, colors);
+    } :
+    // node > 0.8.x
+    function(v, colors) {
+        return util.inspect(v, {
+            colors: colors
+        });
+    }
 );
 
+function stylize(str, color) {
+    if (typeof color === 'string') {
+        color = color.split('.');
+    }
+    var chooser = colors;
+    color.forEach(function(d) {
+        chooser = chooser[d];
+    });
+    return this.useColors ? chooser(str) : str;
+}
+
+var customTypeOf = function(inp) {
+    if (moment.utc(inp, "YYYY-MM-DDTHH:mm:ss.SSSZ", true).isValid())
+        return "ISOStringDate";
+    else if (inp instanceof Date)
+        return "JSDate";
+    else if (inp instanceof moment().__proto__.constructor)
+        return "momentJSDate";
+    else if (Array.isArray(inp))
+        return "array";
+    else if (inp === void 0)
+        return "void0";
+    else if (inp === null)
+        return "null";
+    else {
+        return typeof inp;
+    }
+};
+
+function objectFormatter(obj, spaceString, nSpaces) {
+    if (!nSpaces)
+        nSpaces = 0;
+    if (!spaceString)
+        spaceString = " ";
+    var currentSpaces = "";
+    for (var i = 0; i < nSpaces; i++)
+        currentSpaces += spaceString;
+    var type = " [" + customTypeOf(obj) + "]";
+    var out = "";
+    if (obj != void 0 && obj.toISOString != void 0) {
+        out += obj.toISOString() + type;
+        return out;
+    } else if (!(typeof obj === 'object')) { //string, number...
+        out += obj + type;
+        return out;
+    }
+    nSpaces++;
+    if (nSpaces > 1)
+        out += type;
+    var kString;
+    for (var k in obj) {
+        out += "\n";
+        type = customTypeOf(obj[k]);
+        kString = k;
+        if (type == "number")
+            kString = this.stylize(k, "blue");
+        else if (type == "array")
+            kString = this.stylize(k, "underline");
+        else if (type == "object")
+            kString = this.stylize(k, "bold");
+        else if (type == "string")
+            kString = this.stylize(k, "yellow");
+        else if (type == "ISOStringDate" || type == "momentJSDate" || type == "JSDate")
+            kString = this.stylize(k, "cyan");
+        else if (type == "void0" || type == "null")
+            kString = this.stylize(k, "red");
+        out += currentSpaces + kString + " : " + objectFormatter.apply(this, [obj[k], spaceString, nSpaces]);
+    }
+    return out;
+};
+
 exports.formatters.o = function(v) {
-  return inspect(v, this.useColors)
-    .replace(/\s*\n\s*/g, ' ');
+    return objectFormatter.apply(this, [v, '', 2]);
 };
 
 /**
@@ -80,22 +151,18 @@ exports.formatters.o = function(v) {
  */
 
 function formatArgs() {
-  var args = arguments;
-  var useColors = this.useColors;
-  var name = this.namespace;
+    var args = arguments;
+    var useColors = this.useColors;
+    var name = this.namespace;
 
-  if (useColors) {
-    var c = this.color;
+    if (useColors) {
+        var c = this.color;
 
-    args[0] = '  \u001b[3' + c + ';1m' + name + ' '
-      + '\u001b[0m'
-      + args[0] + '\u001b[3' + c + 'm'
-      + ' +' + exports.humanize(this.diff) + '\u001b[0m';
-  } else {
-    args[0] = new Date().toUTCString()
-      + ' ' + name + ' ' + args[0];
-  }
-  return args;
+        args[0] = '  \u001b[3' + c + ';1m' + name + ' ' + '\u001b[0m' + args[0] + '\u001b[3' + c + 'm' + ' +' + exports.humanize(this.diff) + '\u001b[0m';
+    } else {
+        args[0] = new Date().toUTCString() + ' ' + name + ' ' + args[0];
+    }
+    return args;
 }
 
 /**
@@ -103,7 +170,7 @@ function formatArgs() {
  */
 
 function log() {
-  return stream.write(util.format.apply(this, arguments) + '\n');
+    return stream.write(util.format.apply(this, arguments) + '\n');
 }
 
 /**
@@ -114,13 +181,13 @@ function log() {
  */
 
 function save(namespaces) {
-  if (null == namespaces) {
-    // If you set a process.env field to null or undefined, it gets cast to the
-    // string 'null' or 'undefined'. Just delete instead.
-    delete process.env.DEBUG;
-  } else {
-    process.env.DEBUG = namespaces;
-  }
+    if (null == namespaces) {
+        // If you set a process.env field to null or undefined, it gets cast to the
+        // string 'null' or 'undefined'. Just delete instead.
+        delete process.env.DEBUG;
+    } else {
+        process.env.DEBUG = namespaces;
+    }
 }
 
 /**
@@ -131,7 +198,7 @@ function save(namespaces) {
  */
 
 function load() {
-  return process.env.DEBUG;
+    return process.env.DEBUG;
 }
 
 /**
@@ -141,65 +208,67 @@ function load() {
  * relies on the undocumented `tty_wrap.guessHandleType()` which is also lame.
  */
 
-function createWritableStdioStream (fd) {
-  var stream;
-  var tty_wrap = process.binding('tty_wrap');
+function createWritableStdioStream(fd) {
+    var stream;
+    var tty_wrap = process.binding('tty_wrap');
 
-  // Note stream._type is used for test-module-load-list.js
+    // Note stream._type is used for test-module-load-list.js
 
-  switch (tty_wrap.guessHandleType(fd)) {
-    case 'TTY':
-      stream = new tty.WriteStream(fd);
-      stream._type = 'tty';
+    switch (tty_wrap.guessHandleType(fd)) {
+        case 'TTY':
+            stream = new tty.WriteStream(fd);
+            stream._type = 'tty';
 
-      // Hack to have stream not keep the event loop alive.
-      // See https://github.com/joyent/node/issues/1726
-      if (stream._handle && stream._handle.unref) {
-        stream._handle.unref();
-      }
-      break;
+            // Hack to have stream not keep the event loop alive.
+            // See https://github.com/joyent/node/issues/1726
+            if (stream._handle && stream._handle.unref) {
+                stream._handle.unref();
+            }
+            break;
 
-    case 'FILE':
-      var fs = require('fs');
-      stream = new fs.SyncWriteStream(fd, { autoClose: false });
-      stream._type = 'fs';
-      break;
+        case 'FILE':
+            var fs = require('fs');
+            stream = new fs.SyncWriteStream(fd, {
+                autoClose: false
+            });
+            stream._type = 'fs';
+            break;
 
-    case 'PIPE':
-    case 'TCP':
-      var net = require('net');
-      stream = new net.Socket({
-        fd: fd,
-        readable: false,
-        writable: true
-      });
+        case 'PIPE':
+        case 'TCP':
+            var net = require('net');
+            stream = new net.Socket({
+                fd: fd,
+                readable: false,
+                writable: true
+            });
 
-      // FIXME Should probably have an option in net.Socket to create a
-      // stream from an existing fd which is writable only. But for now
-      // we'll just add this hack and set the `readable` member to false.
-      // Test: ./node test/fixtures/echo.js < /etc/passwd
-      stream.readable = false;
-      stream.read = null;
-      stream._type = 'pipe';
+            // FIXME Should probably have an option in net.Socket to create a
+            // stream from an existing fd which is writable only. But for now
+            // we'll just add this hack and set the `readable` member to false.
+            // Test: ./node test/fixtures/echo.js < /etc/passwd
+            stream.readable = false;
+            stream.read = null;
+            stream._type = 'pipe';
 
-      // FIXME Hack to have stream not keep the event loop alive.
-      // See https://github.com/joyent/node/issues/1726
-      if (stream._handle && stream._handle.unref) {
-        stream._handle.unref();
-      }
-      break;
+            // FIXME Hack to have stream not keep the event loop alive.
+            // See https://github.com/joyent/node/issues/1726
+            if (stream._handle && stream._handle.unref) {
+                stream._handle.unref();
+            }
+            break;
 
-    default:
-      // Probably an error on in uv_guess_handle()
-      throw new Error('Implement me. Unknown stream file type!');
-  }
+        default:
+            // Probably an error on in uv_guess_handle()
+            throw new Error('Implement me. Unknown stream file type!');
+    }
 
-  // For supporting legacy API we put the FD here.
-  stream.fd = fd;
+    // For supporting legacy API we put the FD here.
+    stream.fd = fd;
 
-  stream._isStdio = true;
+    stream._isStdio = true;
 
-  return stream;
+    return stream;
 }
 
 /**

--- a/node.js
+++ b/node.js
@@ -145,7 +145,13 @@ function objectFormatter(obj, spaceString, nSpaces) {
     if (nSpaces > 1)
         out += type;
     var kString;
+    if (obj && typeof obj.toJSON === 'function') {
+        obj = obj.toJSON();
+    }
     for (var k in obj) {
+        if (!obj.hasOwnProperty(k)) {
+            continue;
+        }
         out += "\n";
         type = customTypeOf(obj[k]);
         kString = k;

--- a/node.js
+++ b/node.js
@@ -109,7 +109,25 @@ function objectFormatter(obj, spaceString, nSpaces) {
     var type = " [" + customTypeOf(obj) + "]";
     var out = "";
     if (obj != void 0 && obj.toISOString != void 0) {
-        out += obj.toISOString() + type;
+        out += this.stylize(obj.toISOString() + type, 'cyan');
+        return out;
+    } else if (typeof obj === 'function') {
+        out += this.stylize('[Function: ' + (obj.name === '' ? 'anonymous' : obj.name) + ']', 'cyan');
+        return out;
+    } else if (typeof obj === 'string') { //string, number...
+        out += this.stylize(obj + type, "yellow");
+        return out;
+    } else if (typeof obj === 'number') { //string, number...
+        out += this.stylize(obj + type, "blue");
+        return out;
+    } else if (obj === null) { //string, number...
+        out += this.stylize(obj + type, "red");
+        return out;
+    } else if (typeof obj === 'boolean') { //string, number...
+        out += this.stylize(obj + type, "magenta");
+        return out;
+    } else if (obj === void 0) { //string, number...
+        out += this.stylize(obj + type, "red");
         return out;
     } else if (!(typeof obj === 'object')) { //string, number...
         out += obj + type;
@@ -126,15 +144,17 @@ function objectFormatter(obj, spaceString, nSpaces) {
         if (type == "number")
             kString = this.stylize(k, "blue");
         else if (type == "array")
-            kString = this.stylize(k, "underline");
+            kString = this.stylize(k, "magenta.underline");
         else if (type == "object")
-            kString = this.stylize(k, "bold");
+            kString = this.stylize(k, "black.bold");
         else if (type == "string")
             kString = this.stylize(k, "yellow");
         else if (type == "ISOStringDate" || type == "momentJSDate" || type == "JSDate")
             kString = this.stylize(k, "cyan");
         else if (type == "void0" || type == "null")
             kString = this.stylize(k, "red");
+        // else if (type == 'function')
+        //     kString = this.stylize(k, 'cyan')
         out += currentSpaces + kString + " : " + objectFormatter.apply(this, [obj[k], spaceString, nSpaces]);
     }
     return out;

--- a/node.js
+++ b/node.js
@@ -97,6 +97,7 @@ var customTypeOf = function(inp) {
         return typeof inp;
     }
 };
+var seenObjects = [];
 
 function objectFormatter(obj, spaceString, nSpaces) {
     if (!nSpaces)
@@ -133,6 +134,13 @@ function objectFormatter(obj, spaceString, nSpaces) {
         out += obj + type;
         return out;
     }
+    if (typeof obj === 'object') {
+
+        if (seenObjects.indexOf(obj) !== -1) {
+            return out;
+        }
+        seenObjects.push(obj);
+    }
     nSpaces++;
     if (nSpaces > 1)
         out += type;
@@ -161,6 +169,7 @@ function objectFormatter(obj, spaceString, nSpaces) {
 };
 
 exports.formatters.o = function(v) {
+    seenObjects = [];
     return objectFormatter.apply(this, [v, '   ', 2]);
 };
 

--- a/node.js
+++ b/node.js
@@ -141,7 +141,7 @@ function objectFormatter(obj, spaceString, nSpaces) {
 };
 
 exports.formatters.o = function(v) {
-    return objectFormatter.apply(this, [v, '', 2]);
+    return objectFormatter.apply(this, [v, '   ', 2]);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "colors": "^1.1.2",
+    "moment": "^2.8.3",
     "ms": "0.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I propose my implementation of a replacer for util.inspect which is really poor in terms of help and colors and that can be very confusing and frustrating with large objects.

So what it basically does is replacing the use of utils.inspect for %o types and will beautifully output a clear information about an object without omitting to be deep when displaying.
