### PR TITLE
Expose inspect to allow custom object formatting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -147,6 +147,34 @@ error('now goes to stdout via console.info');
 log('still goes to stdout, but via console.info now');
 ```
 
+### Inspecting objects
+
+Objects can be included in the debug output using the `%o` formatting directive, which displays the object in the inspector on browsers and uses `util.inspect` on Node.  Objects which require special formatting can be output using `.inspect` on the debug instance.  It accepts the same options as `util.inspect` and can be overridden for each namespace:
+
+Example _inspect.js_:
+
+```js
+var debug = require('debug');
+
+var error = debug('app:error');
+// inspect hidden properties of a single object
+error('stdin', error.inspect(new Error('Oh snap'), {showHidden: true}));
+
+var shallow = debug('app:shallow');
+// default depth 0 for all formatted objects in this namespace
+var debugInspect = shallow.inspect;
+shallow.inspect = function(object, options) {
+  return debugInspect.call(this, object, Object.assign({depth: 0}, options));
+};
+shallow('console properties: %o', console);
+```
+
+Some advantages of using `debug.inspect` over `util.inspect` are:
+
+* It avoids unnecessary formatting work when debugging is disabled for the namespace.
+* It shares the same colorization default as the `debug`-formatted output.
+* It becomes a no-op on browsers to avoid interfering with the inspector.
+
 ### Save debug output to a file
 
 You can save all debug statements to a file by piping them.

--- a/browser.js
+++ b/browser.js
@@ -6,6 +6,7 @@
  */
 
 exports = module.exports = require('./debug');
+exports.inspect = inspect;
 exports.log = log;
 exports.formatArgs = formatArgs;
 exports.save = save;
@@ -45,6 +46,14 @@ function useColors() {
     // is firefox >= v31?
     // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
     (navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31);
+}
+
+/**
+ * Compatibility inspect function which returns its argument to allow
+ * unconditional debug.inspect(foo) usage without interfering with inspector.
+ */
+function inspect(o) {
+  return o;
 }
 
 /**

--- a/debug.js
+++ b/debug.js
@@ -120,6 +120,7 @@ function debug(namespace) {
 
   var fn = exports.enabled(namespace) ? enabled : disabled;
 
+  fn.inspect = exports.inspect;
   fn.namespace = namespace;
 
   return fn;

--- a/example/inspect.js
+++ b/example/inspect.js
@@ -1,0 +1,13 @@
+var debug = require('../');
+
+var error = debug('app:error');
+// inspect hidden properties of a single object
+error('stdin', error.inspect(new Error('Oh snap'), {showHidden: true}));
+
+var shallow = debug('app:shallow');
+// default depth 0 for all formatted objects in this namespace
+var debugInspect = shallow.inspect;
+shallow.inspect = function(object, options) {
+  return debugInspect.call(this, object, Object.assign({depth: 0}, options));
+};
+shallow('console: %o', console);


### PR DESCRIPTION
This PR exposes the `inspect` method, which is used to format objects for the `%o` formatting directive, so that it can be called or replaced to suit the needs of users.

Some use cases for this are #185 (inspect with same coloring as debug) and #263 ("better" object formatting).  My primary use case is to log objects with a smaller depth to avoid spamming the logs from large/deep objects.  Other use cases include using the `showHidden` and `customInspect`
options of `util.inspect`.

Why not just use `util.inspect` or another custom formatting function directly?  My major reasons are:
- It takes more code since every debugged object must be formatted.
- It's not available on browsers, complicating Universal/Isomorphic JavaScript (or interfering with the inspector if polyfilled).
- It adds unnecessary formatting overhead when debugging is disabled.
- It doesn't match debug output colorization without using the undocumented `.useColors` property.

Note:  This PR currently exposes the `.inspect` property both on `debug` itself and on the instances.  It can be useful for overriding, but if you wanted to minimize the API expansion, it could be exposed as `_inspect` on `debug` or otherwise hidden.

Thanks for considering,
Kevin
