### PR TITLE
publish "dist"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@ test
 examples
 example
 *.sock
-dist


### PR DESCRIPTION
I really don't know why dist won't be published.
If it's not published, the error in debug (bower component) will exist when I use BowerWebpackPlugin.
The error renders:
```
ERROR in debug (bower component)
Module not found: Error: Cannot resolve 'file' or 'directory' ./dist/debug.js in / {{ project's dir }} /node_modules/debug
 @ debug (bower component) 1:17-43
```