### PR TITLE
Allow line numbers to match debug() call in browser consoles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6,6 +6,7 @@
  */
 
 exports = module.exports = require('./debug');
+exports.is_browser = true;
 exports.log = log;
 exports.formatArgs = formatArgs;
 exports.save = save;

--- a/debug.js
+++ b/debug.js
@@ -66,6 +66,26 @@ function debug(namespace) {
   }
   disabled.enabled = false;
 
+  // override with our specific browser debug() which keeps line numbers in the console 
+  if (exports.is_browser) {
+    var interval = new Date()
+    interval.__proto__ = {
+      now: (new Date()).getTime(),
+      toString: function() {
+        return -this.now + (this.now = new Date().getTime())
+      }
+    }
+
+    // add the `color` if not set
+    var enabled = (function() {
+      var self = enabled
+      if (null == self.useColors) self.useColors = exports.useColors();
+      if (null == self.color && self.useColors) self.color = selectColor();
+
+      return console.log.bind(console, '%c%s +%sms', 'color: ' + self.color, namespace, interval)
+    })()
+  }
+
   // define the `enabled` version
   function enabled() {
 


### PR DESCRIPTION
A possible starting point to fixing file and line number mapping in the browser, #198 as well as for sourcemaps with browserify and webpack, #223 

I'm not sure what of the full formatting scope that is done in enabled() or if it can be integrated into this approach for matching line numbers. This approach has the limitation that it needs to do formatting up front when debug() is called. This is because debug() has to return console.log() directly. i.e: `return console.log.bind(console, '%c%s +%sms', 'color: ' + self.color, namespace, interval)` to preserve line numbers. 

This limits to using bind() to add formatting to console.log(). 

Currently it supports the color formatting of namespace and ms interval. The ms interval is now directly after the namespace due to limitation that we can only prepend arguments to Function.prototype.bind(). 
