### PR TITLE
Prevent crash when used with react-native

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -39,7 +39,8 @@ exports.colors = [
 
 function useColors() {
   // is webkit? http://stackoverflow.com/a/16459606/376773
-  return ('WebkitAppearance' in document.documentElement.style) ||
+  // document is undefined in react-native: https://github.com/facebook/react-native/pull/1632
+  return (typeof document !== 'undefined' && 'WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
     (window.console && (console.firebug || (console.exception && console.table))) ||
     // is firefox >= v31?


### PR DESCRIPTION
Debug currently crashes when used with react-native because document is undefined (unless you explicitly set useColors): https://github.com/facebook/react-native/pull/1632

Gotta love special snowflake JS environments.