### PR TITLE
Node: `%O` (big O) pretty-prints the object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,30 @@ Then, run the program to be debugged as usual.
 
   You can also exclude specific debuggers by prefixing them with a "-" character.  For example, `DEBUG=*,-connect:*` would include all debuggers except those starting with "connect:".
 
+## Formatters
+
+
+  Debug uses [printf-style](https://wikipedia.org/wiki/Printf_format_string) formatting. Below are the officially supported formatters:
+
+| Formatter | Representation |
+|-----------|----------------|
+| `%O`      | Pretty-print an Object on multiple lines. |
+| `%o`      | Pretty-print an Object all on a single line. |
+| `%s`      | String. |
+| `%d`      | Number (both integer and float). |
+| `%j`      | JSON. Replaced with the string '[Circular]' if the argument contains circular references. |
+| `%%`      | Single percent sign ('%'). This does not consume an argument. |
+
+### Custom formatters
+
+  You can add custom formatters by extending the `debug.formatters` object. For example, if you wanted to add support for rendering a Buffer as hex with `%h`, you could do something like:
+
+```js
+debug.formatters.h = (v) => {
+  return v.toString('hex')
+}
+```
+
 ## Browser support
 
   Debug works in the browser as well, currently persisted by `localStorage`. Consider the situation shown below where you have `worker:a` and `worker:b`, and wish to debug both. You can enable this using `localStorage.debug`:

--- a/Readme.md
+++ b/Readme.md
@@ -106,9 +106,15 @@ Then, run the program to be debugged as usual.
   You can add custom formatters by extending the `debug.formatters` object. For example, if you wanted to add support for rendering a Buffer as hex with `%h`, you could do something like:
 
 ```js
-debug.formatters.h = (v) => {
+const createDebug = require('debug')
+createDebug.formatters.h = (v) => {
   return v.toString('hex')
 }
+
+// …elsewhere
+const debug = createDebug('foo')
+debug('this is hex: %h', new Buffer('hello world'))
+//   foo this is hex: 68656c6c6f20776f726c6421 +0ms
 ```
 
 ## Browser support

--- a/debug.js
+++ b/debug.js
@@ -104,7 +104,7 @@ function debug(namespace) {
 
     // apply any `formatters` transformations
     var index = 0;
-    args[0] = args[0].replace(/%([a-z%])/g, function(match, format) {
+    args[0] = args[0].replace(/%([a-zA-Z%])/g, function(match, format) {
       // if we encounter an escaped % then don't increase the array index
       if (match === '%%') return match;
       index++;

--- a/debug.js
+++ b/debug.js
@@ -98,8 +98,8 @@ function debug(namespace) {
     args[0] = exports.coerce(args[0]);
 
     if ('string' !== typeof args[0]) {
-      // anything else let's inspect with %o
-      args = ['%o'].concat(args);
+      // anything else let's inspect with %O
+      args.unshift('%O');
     }
 
     // apply any `formatters` transformations

--- a/node.js
+++ b/node.js
@@ -68,9 +68,13 @@ var inspect = (4 === util.inspect.length ?
   }
 );
 
-exports.formatters.o = exports.formatters.O = function(v) {
+exports.formatters.o = function(v) {
   return inspect(v, this.useColors)
     .replace(/\s*\n\s*/g, ' ');
+};
+
+exports.formatters.O = function(v) {
+  return inspect(v, this.useColors);
 };
 
 /**
@@ -90,10 +94,9 @@ function formatArgs() {
 
   if (useColors) {
     var c = this.color;
+    var prefix = '  \u001b[3' + c + ';1m' + name + ' ' + '\u001b[0m';
 
-    args[0] = '  \u001b[3' + c + ';1m' + name + ' '
-      + '\u001b[0m'
-      + args[0];
+    args[0] = prefix + args[0].split('\n').join('\n' + prefix);
     args.push('\u001b[3' + c + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
   } else {
     args[0] = new Date().toUTCString()


### PR DESCRIPTION
For example:

```js var debug = require('./')('foo')

var o = {
 foo: 'bar',
 b: new Buffer(10),
 c: Math.PI
}

debug('%O', o)
```

Previously:

```
 foo { foo: 'bar', b: <Buffer 01 00 00 00 01 00 00 00 c0 82>, c:
3.141592653589793 } +0ms
```

Now:

```
 foo { foo: 'bar',
 foo   b: <Buffer 01 00 00 00 01 00 00 00 c0 82>,
 foo   c: 3.141592653589793 } +0ms
```

This is a breaking change for anybody relying on the old `%O` behavior.
Though I don't think `%O` was working previously because the formatters
regexp wasn't checking for uppercase formatters (now fixed in this patch).