### PR TITLE
Electron compatibility

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -142,6 +142,12 @@ function load() {
   try {
     r = exports.storage.debug;
   } catch(e) {}
+
+  // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
+  if ('env' in (process || {})) {
+    r = process.env.DEBUG;
+  }
+  
   return r;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+/**
+ * Detect Electron renderer process, which is node, but we should
+ * treat as a browser.
+ */
+
+if ((process || {}).type === 'renderer') {
+  module.exports = require('./browser');
+} else {
+  module.exports = require('./node');
+}

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 
 if ((process || {}).type === 'renderer') {
-  module.exports = require('./browser');
+  module.exports = require('./browser.js');
 } else {
-  module.exports = require('./node');
+  module.exports = require('./node.js');
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify": "9.0.3",
     "mocha": "*"
   },
-  "main": "./node.js",
+  "main": "./index.js",
   "browser": "./browser.js",
   "component": {
     "scripts": {


### PR DESCRIPTION
This PR attempts to resolve a few issues around `debug` when using in Electron apps:

1. Lots and lots of people use `debug` in 3rd party node modules, and they use it via `require`. This means that we'll end up loading `node.js`. While this _should_ work just fine, in Electron, this causes problems because in renderer processes (i.e. processes with a DOM), `tty` and friends don't do The Thing You Expect (in fact, in older versions it used to crash!)

1. When you attempt to fix this by loading `debug/browser.js` explicitly, this _might_ work, but if anyone before you has required `debug`, `exports.log` will have been set to a `tty` output, which means that `debug` is effectively disabled

Instead, we're going to use Electron's `process.type` field to detect whether we're in a renderer process, and if so, we'll load the browser version. We'll also try to fetch `process.env.DEBUG` if LS isn't set to anything