### PR TITLE
fix(browser): should check whether process exists

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -144,7 +144,7 @@ function load() {
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-  if ('env' in (process || {})) {
+  if ('env' in (typeof process === 'undefined' ? {} : process)) {
     r = process.env.DEBUG;
   }
   


### PR DESCRIPTION
Currently, 2.3.1 breaks in the browser. We need to check whether `process` is defined.