### PR TITLE
Fix browser environment detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * treat as a browser.
  */
 
-if (typeof process !== 'undefined' && process.type === 'renderer') {
+if (typeof process === 'undefined' || process.type === 'renderer') {
   module.exports = require('./browser.js');
 } else {
   module.exports = require('./node.js');


### PR DESCRIPTION
The Electron detection has broken Browser detection. Since browsers don't have a `process` variable, they end up include `node.js` and all the `fs`, `net`, etc. modules with it.

This should fix it, however since there aren't any tests (which would've caught this breakage), I can't be 100%.