### PR TITLE
fix(browser): do not override ls debug if found

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -140,15 +140,13 @@ function save(namespaces) {
 function load() {
   var r;
   try {
-    r = exports.storage.debug;
+    return exports.storage.debug;
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
   if (typeof process !== 'undefined' && 'env' in process) {
-    r = process.env.DEBUG;
+    return process.env.DEBUG;
   }
-  
-  return r;
 }
 
 /**


### PR DESCRIPTION
In React apps built with Webpack `process.env.NODE_ENV` is set as a global.  This means `process.env` is a global object.  The current browser code overrides whatever is found in localStorage.  This PR returns early if a debug value is found in localStorage.

Fixes #330 