### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "visionmedia-debug",
-  "main": "dist/debug.js",
+  "main": "./debug.js",
   "homepage": "https://github.com/visionmedia/debug",
   "authors": [
     "TJ Holowaychuk <tj@vision-media.ca>",


### PR DESCRIPTION
Error thrown if using `bower.json` to require files.
`.npmignore` contains `dist`.