### PR TITLE
avoid browserifying entire process polyfill

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -148,8 +148,10 @@ function load() {
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-  if (typeof process !== 'undefined' && 'env' in process) {
-    return process.env.DEBUG;
+  // We're using global.process to avoid Browserify/Webpack including all of:
+  // https://github.com/defunctzombie/node-process
+  if (typeof global !== 'undefined' && global.process && global.process.env) {
+    return global.process.env.DEBUG;
   }
 }
 


### PR DESCRIPTION
Curently, the browser build of `debug` pulls in the entire [process polyfill](https://github.com/defunctzombie/node-process) because it's including a line checking for `process.env.DEBUG` in Electron apps.

One simple way to fix this is to do `global.process` instead of `process` which prevents Browserify/Webpack from trying to pull in the entire polyfill. I tested manually in Electron and confirmed that `global.process` is the same as `process`, so this should be a safe change.

I checked the resulting bundle size using `browserify . | uglifyjs -mc | gzip -c | wc -c` and got:

* Before: **2609 bytes**
* After: **2097 bytes** (~0.5KB saved, ~20% of total size)