### PR TITLE
Use the `developer-tools` 

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+module.exports = function getOptions (depcheck){
+  return {
+    ignoreBinPackage: true,
+    ignoreDirs: [
+      'coverage',
+      'dist',
+      'tmp',
+    ],
+    ignoreMatches: [],
+    parsers: { // the target parsers
+      '*.js': depcheck.parser.es6
+    },
+    detectors: [ // the target detectors 
+      depcheck.detector.requireCallExpression,
+      depcheck.detector.importDeclaration
+    ],
+    specials: [ // the target special parsers 
+      depcheck.special.eslint,
+      depcheck.special.mocha
+    ],
+  };
+};

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+coverage
+node_modules
+lib-cov
+build
+tmp

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  installedESLint: true,
+  env: {
+    es6: true,
+    node: true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.sock
 build
 yarn.lock
+
+coverage/*

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "devDependencies": {
     "browserify": "9.0.3",
-    "mocha": "*"
+    "developer-tools": "0.0.9",
+    "eslint-plugin-mocha": "^4.7.0"
   },
   "main": "./index.js",
   "browser": "./browser.js",
@@ -31,5 +32,21 @@
       "debug/index.js": "browser.js",
       "debug/debug.js": "debug.js"
     }
-  }
+  },
+  "scripts": {
+    "test": "NODE_ENV=test DEBUG=debug-test ./node_modules/.bin/mocha -s 0",
+    "inspect": "NODE_ENV=test node --inspect --debug-brk ./node_modules/.bin/_mocha -s 0 --timeout 60000",
+    "coverage-report": " DEBUG=debug-test ./node_modules/.bin/istanbul-coverage-report",
+    "coverage": "npm run coverage-report && open ./coverage/lcov-report/index.html",
+    "coverage-badge": "./node_modules/.bin/istanbul-cobertura-badger -e 95 -g 85 -b \"${PWD##*/}\"",
+    "lint": "./node_modules/.bin/eslint .",
+    "validate": "./node_modules/.bin/module-validator",
+    "depcheck": "./node_modules/.bin/dependency-checker"
+  },
+  "pre-commit": [
+    "lint",
+    "validate",
+    "depcheck"
+  ],
+  "pre-push": []
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,11 @@
+{
+  plugins: [
+      'mocha'
+  ],
+  env: {
+    mocha: true,
+  },
+  rules: {
+    'global-require': 0,
+  }
+}

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -1,0 +1,50 @@
+const Debug = require('../');
+
+let disabled = null;
+let debug = null;
+
+describe('debug', () => {
+  beforeEach((done) => {
+    debug = new Debug('debug-test');
+    disabled = new Debug('debug-disabled');
+    done();
+  });
+
+  it('should not print a debug line', (done) => {
+    
+    disabled('test debug');
+    done();
+  });
+
+  it('should print a debug line', (done) => {
+    debug('test debug');
+    done();
+  });
+
+  it('should print nothing', (done) => {
+    debug();
+    done();
+  });
+
+  it('should have a bunch of options set', (done) => {
+    process.env.DEBUG_COLORS = 'no';
+    process.env.DEBUG_DEPTH = 10;
+    process.env.DEBUG_SHOW_HIDDEN = 'enabled';
+    debug('options test');
+    done();
+  });
+
+  it('should disable debug', (done) => {
+    Debug.disable();
+    const disabledDebug = new Debug('debug-test');
+    disabledDebug('disabled test');
+    done();
+  });
+
+  it('should check for enabled', (done) => {
+    if (Debug.enabled('debug-test')) {
+      return done();
+    }
+    done('not enabled');
+  });
+});


### PR DESCRIPTION
These are some quick mods I made that will allow for linting, dependency checking, etc to be called from git pre-commit or pre-push hooks, configured in package.json. If you don't think it appropriate for your project feel free to look it over and grab anything that would be useful.

The `'developer-tools` module to provides `depcheck`, `eslint`, `git-validate` (pre-commit npm script hooks), `istanbul` (and coverage badge generator), and `mocha`.

If the following npm scripts fail, then the git commit will be rejected:

```
npm run lint
npm run depcheck
npm run validate
```

Some test coverage is provide in the `/test` folder, and can be used to execute unit tests and code coverage:

```
# run tests
npm run test

# run coverage report, good for CI
npm run coverage-report

# run and open in browser
npm run coverage

# generate a coverage badge after report has run
npm run coverage-badge
```

Debugging the test cases can be started with:

```
npm run inspect
```
