### PR TITLE
Work around debug being loaded in preload scripts

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -37,6 +37,13 @@ exports.colors = [
  */
 
 function useColors() {
+  // NB: In an Electron preload script, document will be defined but not fully
+  // initialized. Since we know we're in Chrome, we'll just detect this case
+  // explicitly
+  if (typeof window !== 'undefined' && 'process' in window && window.process.type === 'renderer') {
+    return true;
+  }
+
   // is webkit? http://stackoverflow.com/a/16459606/376773
   // document is undefined in react-native: https://github.com/facebook/react-native/pull/1632
   return (typeof document !== 'undefined' && 'WebkitAppearance' in document.documentElement.style) ||


### PR DESCRIPTION
This is a follow-on to #324, where if debug is loaded in a preload script (https://github.com/electron/electron/blob/d6e3360aeff6c50820a08af28f1097a0c25d6e3e/docs/api/web-view-tag.md#preload), it will crash in `useColors` because the DOM is not fully set-up yet (`window.document.documentElement` will be undefined, but `window.document` exists)