### PR TITLE
Enable use of custom log function

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -110,7 +110,7 @@ function createDebug(namespace) {
     // apply env-specific formatting (colors, etc.)
     exports.formatArgs.call(self, args);
 
-    var logFn = enabled.log || exports.log || console.log.bind(console);
+    var logFn = debug.log || exports.log || console.log.bind(console);
     logFn.apply(self, args);
   }
 

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { assert, spy } from 'sinon';
 
 import debug from '../index';
 
@@ -9,4 +10,22 @@ describe('debug', () => {
       log('hello world');
     });
   });
-})
+  
+  describe('custom functions', () => {
+    let log;
+
+    beforeEach(() => {
+      debug.enable('test');
+      log = debug('test');
+    });
+
+    context('with log function', () => {
+      it('uses it', () => {
+        log.log = spy();
+        log('using custom log function');
+
+        assert.calledOnce(log.log);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Commit https://github.com/visionmedia/debug/commit/e58d54b46f6b446afd5262d67faea2308e952908 refactored the debug function and removed `enabled` and `disabled` functions.

This breaks the use of custom log function.