### PR TITLE
Use typeof window.process !== 'undefined'

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -40,7 +40,7 @@ function useColors() {
   // NB: In an Electron preload script, document will be defined but not fully
   // initialized. Since we know we're in Chrome, we'll just detect this case
   // explicitly
-  if (typeof window !== 'undefined' && 'process' in window && window.process.type === 'renderer') {
+  if (typeof window !== 'undefined' && typeof window.process !== 'undefined' && window.process.type === 'renderer') {
     return true;
   }
 


### PR DESCRIPTION
'process' in window returns true after window.process = null

Had this problem just now with a javascript game developed by a third party; they were setting window.process = null to support some other library that used that for some detection.

Maybe they are doing it wrong, but this should help if more people are also doing it wrong. :)