### PR TITLE
Fix formatting bug

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -95,7 +95,7 @@ function formatArgs(args) {
   // figure out the correct index to insert the CSS into
   var index = 0;
   var lastC = 0;
-  args[0].replace(/%[a-z%]/g, function(match) {
+  args[0].replace(/%[a-zA-Z%]/g, function(match) {
     if ('%%' === match) return;
     index++;
     if ('%c' === match) {


### PR DESCRIPTION
Was trying to figure out why this doesn't work, turns out it was because `"%capp:signup %c%O%c +2h"` wasn't parsed properly