### PR TITLE
remove explicit `window.debug` export

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -180,8 +180,3 @@ function localstorage() {
     return window.localStorage;
   } catch (e) {}
 }
-
-/** Attach to Window*/
-if (typeof window !== 'undefined') {
-  window.debug = exports;
-}


### PR DESCRIPTION
Exporting to the "outer" scope of the module is more the responsibility
of the module loader (i.e. browserify, webpack, etc.) and thus this
is not necessary. `make test-browser` still passes after this patch.