### PR TITLE
Fix implicit window access

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -48,12 +48,12 @@ function useColors() {
   // document is undefined in react-native: https://github.com/facebook/react-native/pull/1632
   return (typeof document !== 'undefined' && 'WebkitAppearance' in document.documentElement.style) ||
     // is firebug? http://stackoverflow.com/a/398120/376773
-    (typeof window !== 'undefined' && window.console && (console.firebug || (console.exception && console.table))) ||
+    typeof window !== 'undefined' && (window.console && (console.firebug || (console.exception && console.table)) ||
     // is firefox >= v31?
     // https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
     (navigator && navigator.userAgent && navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31) ||
     // double check webkit in userAgent just in case we are in a worker
-    (navigator && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/));
+    (navigator && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/)));
 }
 
 /**


### PR DESCRIPTION
The partial fix before did not address accessing `navigator`.  I whipped this up in the Github editor so you might want to reformat it.  Totally appreciate the work you guys do.  That said, this component is used by a lot of modules, in a lot of situations.  This is the 2nd week in a row where debug has broken my build process.  Expanding the test suite to test with browser and non-browser situations would be great.