### PR TITLE
Make millisecond timer namespace specific and allow 'always enabled' output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Then, run the program to be debugged as usual.
 
 ## Conventions
 
-  If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser".
+  If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser".  If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable.  You can then use it for normal output as well as debug output.
 
 ## Wildcards
 

--- a/src/debug.js
+++ b/src/debug.js
@@ -167,6 +167,9 @@ function disable() {
  */
 
 function enabled(name) {
+  if (name[name.length - 1] === '*') {
+    return true;
+  }
   var i, len;
   for (i = 0, len = exports.skips.length; i < len; i++) {
     if (exports.skips[i].test(name)) {

--- a/src/debug.js
+++ b/src/debug.js
@@ -29,12 +29,6 @@ exports.skips = [];
 exports.formatters = {};
 
 /**
- * Previous log timestamp.
- */
-
-var prevTime;
-
-/**
  * Select a color.
  * @param {String} namespace
  * @return {Number}
@@ -61,6 +55,8 @@ function selectColor(namespace) {
  */
 
 function createDebug(namespace) {
+
+  var prevTime;
 
   function debug() {
     // disabled?


### PR DESCRIPTION
When debugging node apps, I find it much more useful for the
millisecond timer to be relative to last message from the same
namespace instead of any message. This is especially true when I'm
debugging across multiple libraries or multiple levels in the same
module and I'm interested in seeing all the messages but also need to
compare times from specific levels.

Also, Having to deal with 2 different logging mechanisms, one for debugging
and one for normal output, can be a nuisance.  It would be much easier to
always use the same facility and semantics for both.  This patch allows
an 'always enabled' namespace to be specified by appending a single '*'
to the namespace name.