### PR TITLE
added names and skips arrays erasing on enable call

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -138,6 +138,9 @@ function createDebug(namespace) {
 function enable(namespaces) {
   exports.save(namespaces);
 
+  exports.names = [];
+  exports.skips = [];
+
   var split = (namespaces || '').split(/[\s,]+/);
   var len = split.length;
 


### PR DESCRIPTION
Namespaces couldn't be disabled once enabled.
This PR fixed this issue.

test:
```
let debug = require('debug');

console.log(1, debug.enabled('test'));

debug.enable('test');
console.log(2, debug.enabled('test'));

debug.disable();
console.log(3, debug.enabled('test'));
```

expected print:
```
1 false
2 true
3 false
```