### PR TITLE
Fixed IE8 "Expected identifier" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.6.1 / 2017-01-16
+==================
+
+  * Fix: Module's `export default` syntax fix for IE8 `Expected identifier` error
 
 2.6.0 / 2016-12-28
 ==================

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "debug",
   "repo": "visionmedia/debug",
   "description": "small debugging utility",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "keywords": [
     "debug",
     "log",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/visionmedia/debug.git"

--- a/src/debug.js
+++ b/src/debug.js
@@ -6,7 +6,7 @@
  * Expose `debug()` as the module.
  */
 
-exports = module.exports = createDebug.debug = createDebug.default = createDebug;
+exports = module.exports = createDebug.debug = createDebug['default'] = createDebug;
 exports.coerce = coerce;
 exports.disable = disable;
 exports.enable = enable;


### PR DESCRIPTION
"default" is reserved word in IE8. So it produces 'Expected identifier' error. Fixed that with quotes.