### PR TITLE
Whitelist DEBUG_FD for values 1 and 2 only Fixes #410

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -58,7 +58,7 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
  *   $ DEBUG_FD=3 node script.js 3>debug.log
  */
 
-if ('DEBUG_FD' in process.env && !('FORCE_COLOR' in process.env) && !('DEBUG_COLORS' in process.env)  ) {
+if ('DEBUG_FD' in process.env && !('DEBUG_COLORS' in process.env && process.env.DEBUG_FD == 1)) {
   util.deprecate(function(){}, '`DEBUG_FD` is deprecated. Override `debug.log` if you want to use a different log function (https://git.io/vMUyr)')()
 }
 

--- a/src/node.js
+++ b/src/node.js
@@ -58,7 +58,7 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
  *   $ DEBUG_FD=3 node script.js 3>debug.log
  */
 
-if ('DEBUG_FD' in process.env) {
+if ('DEBUG_FD' in process.env && !('FORCE_COLOR' in process.env) && !('DEBUG_COLORS' in process.env)  ) {
   util.deprecate(function(){}, '`DEBUG_FD` is deprecated. Override `debug.log` if you want to use a different log function (https://git.io/vMUyr)')()
 }
 

--- a/src/node.js
+++ b/src/node.js
@@ -61,7 +61,7 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
 var fd = parseInt(process.env.DEBUG_FD, 10) || 2;
 
 if (1 !== fd && 2 !== fd) {
-  util.deprecate(function(){}, '`DEBUG_FD` is deprecated. Override `debug.log` if you want to use a different log function (https://git.io/debug_fd)')()
+  util.deprecate(function(){}, 'except for stderr(2) and stdout(1), any other usage of DEBUG_FD is deprecated. Override debug.log if you want to use a different log function (https://git.io/debug_fd)')()
 }
 
 var stream = 1 === fd ? process.stdout :

--- a/src/node.js
+++ b/src/node.js
@@ -58,11 +58,12 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
  *   $ DEBUG_FD=3 node script.js 3>debug.log
  */
 
-if ('DEBUG_FD' in process.env && !('DEBUG_COLORS' in process.env && process.env.DEBUG_FD == 1)) {
-  util.deprecate(function(){}, '`DEBUG_FD` is deprecated. Override `debug.log` if you want to use a different log function (https://git.io/vMUyr)')()
+var fd = parseInt(process.env.DEBUG_FD, 10) || 2;
+
+if (1 !== fd && 2 !== fd) {
+  util.deprecate(function(){}, '`DEBUG_FD` is deprecated. Override `debug.log` if you want to use a different log function (https://git.io/debug_fd)')()
 }
 
-var fd = parseInt(process.env.DEBUG_FD, 10) || 2;
 var stream = 1 === fd ? process.stdout :
              2 === fd ? process.stderr :
              createWritableStdioStream(fd);


### PR DESCRIPTION
## UPDATED: Please see discussion below 

### Short description
This PR tries to smartly hide DEBUG_FD deprecation annoying warning if this conditions are met:
- `DEBUG_COLORS` env variable is detected (webstorm uses that)
-  `DEBUG_FD `is set to 1 (default value by web-storm & idea)


So if user customizes `DEBUG_FD` to something other than 1 she will still get the notification but this saves majority of other users

### Long Story
As discussed in #410 Also [Here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000011770-IDEA-console-just-warning-) and [Here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000019410-DEBUG-FD-being-defined-in-nodes-process-env-v7-deprecated?page=1#community_comment_115000031430) after `DEBUG_FD` is deprecated many & many end users who actually don't even use `DEBUG_FD` variable are affected (including all express& react-native users).  This issue will not be resolved at lease next idea release (end of march) also if it resolves in that way webstorm users will totally lose error colors!
