### PR TITLE
Use Date#toISOString() instead to Date#toUTCString() when output is n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Then, run the program to be debugged as usual.
 
   ![](http://f.cl.ly/items/2i3h1d3t121M2Z1A3Q0N/Screenshot.png)
 
-  When stdout is not a TTY, `Date#toUTCString()` is used, making it more useful for logging the debug information as shown below:
+  When stdout is not a TTY, `Date#toISOString()` is used, making it more useful for logging the debug information as shown below:
 
   ![](http://f.cl.ly/items/112H3i0e0o0P0a2Q2r11/Screenshot.png)
 

--- a/src/node.js
+++ b/src/node.js
@@ -114,7 +114,7 @@ function formatArgs(args) {
     args[0] = prefix + args[0].split('\n').join('\n' + prefix);
     args.push('\u001b[3' + c + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
   } else {
-    args[0] = new Date().toUTCString()
+    args[0] = new Date().toISOString()
       + ' ' + name + ' ' + args[0];
   }
 }


### PR DESCRIPTION
Use Date#toISOString() instead to Date#toUTCString() when output is not a TTY, which:
- is easier to parse (does not contains spaces, day name, and everything is written with numbers)
- contains milliseconds