### PR TITLE
process.env.DEBUG ignored in Electron apps for all cases

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -148,14 +148,17 @@ function save(namespaces) {
  */
 
 function load() {
+  var r;
   try {
-    return exports.storage.debug;
+    r = exports.storage.debug;
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-  if (typeof process !== 'undefined' && 'env' in process) {
-    return process.env.DEBUG;
+  if (!r && typeof process !== 'undefined' && 'env' in process) {
+    r = process.env.DEBUG;
   }
+
+  return r;
 }
 
 /**


### PR DESCRIPTION
This PR fixes the code introduced in #331 that breaks the Electron case, but also prioritizes LocalStorage if present