### PR TITLE
chore(): ignore bower.json in npm installations.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ example
 dist
 yarn.lock
 coverage
+bower.json


### PR DESCRIPTION
This may confuse and break some loaders (e.g. webpack) that are configured to read bower.json descriptor files (see https://github.com/codewizz/bower-resolve-webpack-plugin/pull/2#pullrequestreview-29257842). Installed NPM modules do not require bower.json ~~as it also points to a non-existent file (`dist/debug.js`)~~. *Edited: that was in v2.2.0.*

This is common for isomorphic libraries (e.g. https://github.com/visionmedia/superagent/commit/8ae738056afae55df77218d7c17c39e2bb54b950) (just noticed superagent is from you guys as well :D)