### PR TITLE
`enabled()` updates existing debug instances, add `destroy()` function

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -14,6 +14,11 @@ exports.enabled = enabled;
 exports.humanize = require('ms');
 
 /**
+ * Active `debug` instances.
+ */
+exports.instances = [];
+
+/**
  * The currently active debug mode names, and names to skip.
  */
 
@@ -120,6 +125,8 @@ function createDebug(namespace) {
     exports.init(debug);
   }
 
+  exports.instances.push(debug);
+
   return debug;
 }
 
@@ -148,6 +155,11 @@ function enable(namespaces) {
     } else {
       exports.names.push(new RegExp('^' + namespaces + '$'));
     }
+  }
+
+  for (var i = 0; i < exports.instances.length; i++) {
+    var instance = exports.instances[i];
+    instance.enabled = exports.enabled(instance.namespace);
   }
 }
 

--- a/src/debug.js
+++ b/src/debug.js
@@ -119,6 +119,7 @@ function createDebug(namespace) {
   debug.enabled = exports.enabled(namespace);
   debug.useColors = exports.useColors();
   debug.color = selectColor(namespace);
+  debug.destroy = destroy;
 
   // env-specific initialization logic for debug instances
   if ('function' === typeof exports.init) {
@@ -128,6 +129,11 @@ function createDebug(namespace) {
   exports.instances.push(debug);
 
   return debug;
+}
+
+function destroy () {
+  const index = exports.instances.indexOf(this)
+  exports.instances.splice(index, 1)
 }
 
 /**


### PR DESCRIPTION
Breaking change! For v3.