### PR TITLE
Passing settings to debug on runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,6 @@ Then, run the program to be debugged as usual.
   [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
   for the complete list.
 
-  In case the name debug cause conflicts on your project, use the settings 
-  
-
 ## Formatters
 
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,29 @@ setInterval(function(){
 }, 1000);
 ```
 
- The __DEBUG__ environment variable is then used to enable these based on space or comma-delimited names. Here are some examples:
+ By default, the __DEBUG__ environment variable is then used to enable these based on space or comma-delimited names. Here are some examples:
 
   ![debug http and worker](http://f.cl.ly/items/18471z1H402O24072r1J/Screenshot.png)
 
   ![debug worker](http://f.cl.ly/items/1X413v1a3M0d3C2c1E0i/Screenshot.png)
+
+#### Are you using _DEBUG_ for something else?
+
+ You can easily set another variable to look up for debug information. Just pass that to the settings function of the debug factory as _envVarName_. This works the same with LocalStorage.
+
+```js
+var debug = require('debug')
+  , log = debug('worker');
+
+  debug.settings({
+    envVarName: 'MY_VAR'
+  });
+setInterval(function(){
+  log('doing some work');
+}, 1000); 
+```
+
+ All other variables you want to set for debug, should start with __MY_VAR__. For example: __MY_VAR_COLORS__, __MY_VAR_FD__, etc.
 
 #### Windows note
 
@@ -105,12 +123,14 @@ Then, run the program to be debugged as usual.
 | `DEBUG_DEPTH` | Object inspection depth. |
 | `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
 
-
   __Note:__ The environment variables beginning with `DEBUG_` end up being
   converted into an Options object that gets used with `%o`/`%O` formatters.
   See the Node.js documentation for
   [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options)
   for the complete list.
+
+  In case the name debug cause conflicts on your project, use the settings 
+  
 
 ## Formatters
 

--- a/example/specificKey.js
+++ b/example/specificKey.js
@@ -1,0 +1,32 @@
+var debug = require('../')
+  , initLog = debug('init')
+  , requestLog = debug('req')
+  , http = require('http')
+  , name = 'My App';
+
+// fake app
+
+initLog('booting %s', name);
+
+// You can define the key where you wan't to look for your debug info.
+// By default we use DEBUG, but you can use a custom one in case DEBUG
+// variable is being used for something else.
+// With the example below, you can set CUSTOM_FLAG with namespaces,
+// CUSTOM_FLAG_FD for File Descriptor, and CUSTOM_FLAG_COLORS for colors.
+// Play a little bit by setting those vars with different values.
+// 
+// NOTE: The setting change will start working after it's run. So the log for
+// booting will depend on what you have on DEBUG var, because it's before
+// settings update.
+debug.settings({ envVarName: 'CUSTOM_FLAG' });
+
+http.createServer(function(req, res){
+  requestLog(req.method + ' ' + req.url);
+  res.end('hello\n');
+}).listen(3000, function(){
+  initLog('listening on port 3000');
+});
+
+// fake worker of some kind
+
+require('./worker');

--- a/src/browser.js
+++ b/src/browser.js
@@ -155,7 +155,7 @@ function load() {
     r = exports.storage[envVarName];
   } catch(e) {}
 
-  // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
+  // If debug mode isn't set in LS, and we're in Electron, try to load from process.env
   if (!r && typeof process !== 'undefined' && 'env' in process) {
     r = process.env[envVarName];
   }

--- a/src/browser.js
+++ b/src/browser.js
@@ -76,7 +76,7 @@ exports.formatters.j = function(v) {
  */
 
 function formatArgs(args) {
-  var useColors = this.useColors;
+  var useColors = this.useColors();
 
   args[0] = (useColors ? '%c' : '')
     + this.namespace
@@ -131,11 +131,12 @@ function log() {
  */
 
 function save(namespaces) {
+  var envVarName = exports.settings().envVarName;
   try {
     if (null == namespaces) {
-      exports.storage.removeItem('debug');
+      exports.storage.removeItem(envVarName);
     } else {
-      exports.storage.debug = namespaces;
+      exports.storage[envVarName] = namespaces;
     }
   } catch(e) {}
 }
@@ -148,14 +149,15 @@ function save(namespaces) {
  */
 
 function load() {
+  var envVarName = exports.settings().envVarName;
   var r;
   try {
-    r = exports.storage.debug;
+    r = exports.storage[envVarName];
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
   if (!r && typeof process !== 'undefined' && 'env' in process) {
-    r = process.env.DEBUG;
+    r = process.env[envVarName];
   }
 
   return r;

--- a/src/debug.js
+++ b/src/debug.js
@@ -49,7 +49,10 @@ function settings(newSettings) {
   // By using enable with undefined we delete the old key data.
   enable();
 
-  options = Object.assign({}, options, newSettings);
+  // We only care about properties we defined.
+  for (var opt in options) {
+    options[opt] = newSettings[opt];    
+  }
 
   if ('function' === typeof exports.update) {
     // If we have an update function, run it after settings are updated.

--- a/src/node.js
+++ b/src/node.js
@@ -18,6 +18,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.update = update;
 
 /**
  * Colors.
@@ -30,26 +31,29 @@ exports.colors = [6, 2, 3, 4, 5, 1];
  *
  *   $ DEBUG_COLORS=no DEBUG_DEPTH=10 DEBUG_SHOW_HIDDEN=enabled node script.js
  */
+function parseInspectOpts() {
+  exports.inspectOpts = Object.keys(process.env).filter(function (key) {
+    return new RegExp('^' + exports.settings().envVarName, 'i').test(key);
+  }).reduce(function (obj, key) {
+    // camel-case
+    var prop = key
+      .substring(exports.settings().envVarName.length)
+      .toLowerCase()
+      .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
 
-exports.inspectOpts = Object.keys(process.env).filter(function (key) {
-  return /^debug_/i.test(key);
-}).reduce(function (obj, key) {
-  // camel-case
-  var prop = key
-    .substring(6)
-    .toLowerCase()
-    .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
+    // coerce string value into JS value
+    var val = process.env[key];
+    if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
+    else if (/^(no|off|false|disabled)$/i.test(val)) val = false;
+    else if (val === 'null') val = null;
+    else val = Number(val);
 
-  // coerce string value into JS value
-  var val = process.env[key];
-  if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
-  else if (/^(no|off|false|disabled)$/i.test(val)) val = false;
-  else if (val === 'null') val = null;
-  else val = Number(val);
-
-  obj[prop] = val;
-  return obj;
-}, {});
+    obj[prop] = val;
+    return obj;
+  }, {});
+}
+// Parse initial options
+parseInspectOpts();
 
 /**
  * The file descriptor to write the `debug()` calls to.
@@ -57,22 +61,30 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
  *
  *   $ DEBUG_FD=3 node script.js 3>debug.log
  */
+var stream = {};
 
-var fd = parseInt(process.env.DEBUG_FD, 10) || 2;
+function setStream() {
+  var FDEnvVarName = exports.settings().envVarName.toUpperCase() + '_FD';
+  var fd = parseInt(process.env[FDEnvVarName], 10) || 2;  
 
-if (1 !== fd && 2 !== fd) {
-  util.deprecate(function(){}, 'except for stderr(2) and stdout(1), any other usage of DEBUG_FD is deprecated. Override debug.log if you want to use a different log function (https://git.io/debug_fd)')()
+  if (1 !== fd && 2 !== fd) {
+    util.deprecate(function(){}, 'except for stderr(2) and stdout(1), any other usage of DEBUG_FD is deprecated. Override debug.log if you want to use a different log function (https://git.io/debug_fd)')()
+  }
+  stream = 1 === fd ? process.stdout :
+          2 === fd ? process.stderr :
+          createWritableStdioStream(fd);
 }
-
-var stream = 1 === fd ? process.stdout :
-             2 === fd ? process.stderr :
-             createWritableStdioStream(fd);
+// Set initial stream.
+setStream();
 
 /**
  * Is stdout a TTY? Colored output is enabled when `true`.
  */
 
 function useColors() {
+  var FDEnvVarName = exports.settings().envVarName.toUpperCase() + '_FD';  
+  var fd = parseInt(process.env[FDEnvVarName], 10) || 2;    
+
   return 'colors' in exports.inspectOpts
     ? Boolean(exports.inspectOpts.colors)
     : tty.isatty(fd);
@@ -83,7 +95,7 @@ function useColors() {
  */
 
 exports.formatters.o = function(v) {
-  this.inspectOpts.colors = this.useColors;
+  this.inspectOpts.colors = this.useColors();
   return util.inspect(v, this.inspectOpts)
     .replace(/\s*\n\s*/g, ' ');
 };
@@ -93,7 +105,7 @@ exports.formatters.o = function(v) {
  */
 
 exports.formatters.O = function(v) {
-  this.inspectOpts.colors = this.useColors;
+  this.inspectOpts.colors = this.useColors();
   return util.inspect(v, this.inspectOpts);
 };
 
@@ -105,7 +117,7 @@ exports.formatters.O = function(v) {
 
 function formatArgs(args) {
   var name = this.namespace;
-  var useColors = this.useColors;
+  var useColors = this.useColors();
 
   if (useColors) {
     var c = this.color;
@@ -135,12 +147,13 @@ function log() {
  */
 
 function save(namespaces) {
+  var envVarName = exports.settings().envVarName.toUpperCase();
   if (null == namespaces) {
     // If you set a process.env field to null or undefined, it gets cast to the
     // string 'null' or 'undefined'. Just delete instead.
-    delete process.env.DEBUG;
+    delete process.env[envVarName];
   } else {
-    process.env.DEBUG = namespaces;
+    process.env[envVarName] = namespaces;
   }
 }
 
@@ -152,7 +165,7 @@ function save(namespaces) {
  */
 
 function load() {
-  return process.env.DEBUG;
+  return process.env[exports.settings().envVarName.toUpperCase()];
 }
 
 /**
@@ -229,9 +242,20 @@ function createWritableStdioStream (fd) {
  * Create a new `inspectOpts` object in case `useColors` is set
  * differently for a particular `debug` instance.
  */
-
 function init (debug) {
   debug.inspectOpts = util._extend({}, exports.inspectOpts);
+}
+/**
+ * Update logic for `debug` instances.
+ *
+ * Resets the stream, re-parses the inspect options and corrects them for the instances.
+ */
+function update(instances) {
+  parseInspectOpts();
+  setStream();
+  for (var i = 0; i < instances.length; i++) {
+    init(instances[i]);
+  }
 }
 
 /**

--- a/src/node.js
+++ b/src/node.js
@@ -55,20 +55,21 @@ function parseInspectOpts() {
 // Parse initial options
 parseInspectOpts();
 
+var stream = {};
+
 /**
  * The file descriptor to write the `debug()` calls to.
- * Set the `DEBUG_FD` env variable to override with another value. i.e.:
+ * Set the FD env variable to override with another value. i.e.:
  *
  *   $ DEBUG_FD=3 node script.js 3>debug.log
  */
-var stream = {};
 
 function setStream() {
   var FDEnvVarName = exports.settings().envVarName.toUpperCase() + '_FD';
   var fd = parseInt(process.env[FDEnvVarName], 10) || 2;  
 
   if (1 !== fd && 2 !== fd) {
-    util.deprecate(function(){}, 'except for stderr(2) and stdout(1), any other usage of DEBUG_FD is deprecated. Override debug.log if you want to use a different log function (https://git.io/debug_fd)')()
+    util.deprecate(function(){}, 'except for stderr(2) and stdout(1), any other usage of the FD variable is deprecated. Override debug.log if you want to use a different log function (https://git.io/debug_fd)')()
   }
   stream = 1 === fd ? process.stdout :
           2 === fd ? process.stderr :

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -31,6 +31,14 @@ describe('debug', function () {
     expect(debug.enable(true)).to.not.throw;
   });
 
+  it('allows for settings update', function () {
+    expect(debug.settings({ envVarName: 'test' })).to.not.throw;
+  });
+
+  it('and can continue logging after that', function () {
+    expect(log('hello world')).to.not.throw;
+  });
+
   context('with log function', function () {
 
     beforeEach(function () {


### PR DESCRIPTION
We use the library on an SDK package, and we had users with issues because they were using the ENV Variable **DEBUG** for other stuff.

We needed a way to redefine the variable that debug is looking for (both for Node and Browser). I've done some extra work so we can have a settings object, instead of just defining what I needed.

Please, take a look and let me know of any changes you may need. 
Also, it would be great if this feature is included in v3! I'll read more about it, but it looks promising already :)

Best regards.