### PR TITLE
Inline extend function in node implementation

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -231,7 +231,12 @@ function createWritableStdioStream (fd) {
  */
 
 function init (debug) {
-  debug.inspectOpts = util._extend({}, exports.inspectOpts);
+  debug.inspectOpts = {};
+
+  var keys = Object.keys(exports.inspectOpts);
+  for (var i = 0; i < keys.length; i++) {
+    debug.inspectOpts[keys[i]] = exports.inspectOpts[keys[i]];
+  }
 }
 
 /**


### PR DESCRIPTION
This is a proposed solution for the Node.js 0.6 breakage I reported in #450 . This replaces the use of `util._extend` with an inlined version of the minimal implementation.