### PR TITLE
Fix browser detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  * treat as a browser.
  */
 
-if (typeof process !== 'undefined' && process.type === 'renderer') {
+if (typeof process === 'undefined' || process.type === 'renderer') {
   module.exports = require('./browser.js');
 } else {
   module.exports = require('./node.js');


### PR DESCRIPTION
Currently in main script it is assumed that browser environment defines `process` object, that's not right:

![screen shot 2017-05-15 at 10 55 00](https://cloud.githubusercontent.com/assets/122434/26049884/eefd4310-395c-11e7-91bb-e40df854475b.png)

I stumbled on it, when I tried to use debug in portable modules (ones that work on both server and client side) in a browser (via CJS bundler).

For time-being I'm relying on following [workaround](https://github.com/medikoo/onejs.org/blob/2c4a27ddf2ac04090f3055ea7e1671c9329bd472/client/lib/debug-workaround.js#L6-L8), but that's not quite beautiful.

This patch fixes it (and doesn't break proper Electron detection)