### PR TITLE
Add a wrapper to allow for minifying out debug in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon-chai": "^2.8.0"
   },
   "main": "./src/index.js",
-  "browser": "./src/browser.js",
+  "browser": "./src/browser-wrap.js",
   "component": {
     "scripts": {
       "debug/index.js": "browser.js",

--- a/src/browser-wrap.js
+++ b/src/browser-wrap.js
@@ -1,0 +1,10 @@
+if (process.env.NODE_ENV !== 'production') {
+  module.exports = require('./browser')
+} else {
+  function noop () {}
+  module.exports = noop
+  module.exports.log = noop
+  module.exports.formatArgs = noop
+  module.exports.save = noop
+  module.exports.useColors = noop
+}


### PR DESCRIPTION
This is an experimental idea to enable minifying out the debug code in production builds.  Started as a conversation [here](https://github.com/pillarjs/router/issues/57#issuecomment-309232351).  Adding a wrapper like this means you could do something like:

```
$ browserify -t [envify --NODE_ENV="production"] -g uglifyify src/browser-wrap.js
```

And it would replace all of the code you should not be running in your production builds with a set of `noop` methods:

```javascript
(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
{function noop(){}module.exports=noop,module.exports.log=noop,module.exports.formatArgs=noop,module.exports.save=noop,module.exports.useColors=noop}

},{}]},{},[1]);
```

This obviously removes the ability to turn debugging on in production builds, which is probably considered a breaking change.  Also I totally understand if the maintainers do not want to go this route, but I just thought I would open a PR to discuss.