### PR TITLE
Dedicated handling of AWS Lambda environment

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -66,6 +66,8 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
   return obj;
 }, {});
 
+var isAWSLambdaEnv = Boolean(process.env.AWS_LAMBDA_LOG_STREAM_NAME);
+
 /**
  * Is stdout a TTY? Colored output is enabled when `true`.
  */
@@ -112,6 +114,8 @@ function formatArgs(args) {
 
     args[0] = prefix + args[0].split('\n').join('\n' + prefix);
     args.push(colorCode + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
+  } else if (isAWSLambdaEnv) {
+    args[0] = name + ' ' + args[0];
   } else {
     args[0] = new Date().toISOString()
       + ' ' + name + ' ' + args[0];
@@ -123,6 +127,11 @@ function formatArgs(args) {
  */
 
 function log() {
+  if (isAWSLambdaEnv) {
+    // AWS Lambda env decorates console.* methods with meaningful debug info
+    // therefore we rely on them directly
+    return console.error(util.format.apply(util, arguments));
+  }
   return process.stderr.write(util.format.apply(util, arguments) + '\n');
 }
 


### PR DESCRIPTION
Recently I'm working with projects that stand on Serverless architecture (AWS Lambda), and found that debug doesn't play well with that.

Thing is that in AWS Lambda ( http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html ) all console.* methods are internally decorated, so then all logs are combined with meaningful info on time and invocation id), so outcome of `console.log("this is console log");` etc. ends as:

![screen shot 2017-07-17 at 11 48 42](https://user-images.githubusercontent.com/122434/28263109-e59b9974-6ae5-11e7-96a1-e2969ce1df2b.png)

Now `debug` (as run at v2.6.8) by defaults logs as:

![screen shot 2017-07-17 at 11 49 52](https://user-images.githubusercontent.com/122434/28263268-643d9dc2-6ae6-11e7-8044-bf478d74c0ad.png)

This patch ensures that eventual `debug` in case of being run in AWS Lambda outputs logs via `console.error` therefore comes out as following:

![screen shot 2017-07-17 at 11 51 47](https://user-images.githubusercontent.com/122434/28263248-53f37b9e-6ae6-11e7-9794-7cd0715ad740.png)






