### PR TITLE
Drop usage of `chrome.storage` (or make the storage backend pluggable)

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -10,10 +10,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
-exports.storage = 'undefined' != typeof chrome
-               && 'undefined' != typeof chrome.storage
-                  ? chrome.storage.local
-                  : localstorage();
+exports.storage = localstorage();
 
 /**
  * Colors.


### PR DESCRIPTION
The browser version assumes that chrome.storage.local uses an API which is compatible with localStorage; which is not the case. Even though I am using chrome.storage.local for my Chrome extension, I would much prefer to keep debug's variable in localStorage, as I consider chrome.storage.local the 'private space' of my extension.

This change obviates the need to support multiple storage types. But if storage type is important, how about supporting a custom storage facility, including chrome.storage.sync? I.e. the user would provide an object that follows the conventions. Just a thought - I certainly don't see the need at this point though.