### PR TITLE
Add timed sections

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -10,6 +10,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.hrtime = hrtimeInit();
 exports.storage = 'undefined' != typeof chrome
                && 'undefined' != typeof chrome.storage
                   ? chrome.storage.local
@@ -80,20 +81,28 @@ exports.formatters.j = function(v) {
  * @api public
  */
 
-function formatArgs(args) {
+function formatArgs(args, section) {
   var useColors = this.useColors;
 
   args[0] = (useColors ? '%c' : '')
     + this.namespace
     + (useColors ? ' %c' : ' ')
+    + (section ? (section.title + (useColors ? ' %c' : ' ')) : '')
     + args[0]
     + (useColors ? '%c ' : ' ')
-    + '+' + exports.humanize(this.diff);
+    + '+' + exports.humanize(this.diff)
+    + (section && section.complete ? ('%c (delta ' + (useColors ? '%c+' : '+') + exports.humanize(section.deltaTime) + (useColors ? '%c)' : ')')) : '');
 
   if (!useColors) return;
 
   var c = 'color: ' + this.color;
-  args.splice(1, 0, c, 'color: inherit')
+  var inherit = 'color: inherit';
+
+  if (section) {
+    args.splice(1, 0, c, inherit + '; font-weight: bold', 'font-weight: normal');
+  } else {
+    args.splice(1, 0, c, inherit);
+  }
 
   // the final "%c" is somewhat tricky, because there could be other
   // arguments passed either before or after the %c, so we need to
@@ -110,7 +119,11 @@ function formatArgs(args) {
     }
   });
 
-  args.splice(lastC, 0, c);
+  if (section && section.complete) {
+    args.splice(lastC - 2, 0, c, inherit, c, inherit);
+  } else {
+    args.splice(lastC, 0, c);
+  }
 }
 
 /**
@@ -164,6 +177,22 @@ function load() {
   }
 
   return r;
+}
+
+/**
+ * Browser implementation of hrtime().
+ *
+ * Follows the spec outlined in debug.begin() (see debug.js).
+ *
+ * If the browser has support for `window.performance.now()`,
+ * then it is used. Otherwise, it falls back to `Date.now()`.
+ */
+function hrtimeInit() {
+  var nowfn = window && window.performance && window.performance.now ? window.performance.now.bind(window.performance) : Date.now;
+  return function (prev) {
+    var now = nowfn();
+    return prev ? (now - prev) : now;
+  };
 }
 
 /**

--- a/src/node.js
+++ b/src/node.js
@@ -18,6 +18,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.hrtime = hrtime;
 
 /**
  * Colors.
@@ -101,17 +102,22 @@ exports.formatters.O = function(v) {
  * @api public
  */
 
-function formatArgs(args) {
+function formatArgs(args, section) {
   var name = this.namespace;
   var useColors = this.useColors;
 
   if (useColors) {
     var c = this.color;
     var colorCode = '\u001b[3' + (c < 8 ? c : '8;5;' + c);
-    var prefix = '  ' + colorCode + ';1m' + name + ' ' + '\u001b[0m';
+    var prefix = '  ' + colorCode + ';1m' + name + '\u001b[0m ';
+    var sectionPrefix = section ? ('\u001b[1m' + section.title + '\u001b[0m ') : '';
 
-    args[0] = prefix + args[0].split('\n').join('\n' + prefix);
+    args[0] = prefix + sectionPrefix + args[0].split('\n').join('\n' + prefix);
     args.push(colorCode + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
+
+    if (section && section.complete) {
+      args.push('(delta ' + colorCode + 'm+' + exports.humanize(section.deltaTime) + '\u001b[0m)');
+    }
   } else {
     args[0] = new Date().toISOString()
       + ' ' + name + ' ' + args[0];
@@ -168,6 +174,23 @@ function init (debug) {
   for (var i = 0; i < keys.length; i++) {
     debug.inspectOpts[keys[i]] = exports.inspectOpts[keys[i]];
   }
+}
+
+/**
+ * Wrapper around Node's process.hrtime().
+ *
+ * As per the spec defined by debug.begin() (see debug.js),
+ * this function returns normally when there is no argument,
+ * but returns a delta float in the event that there is.
+ */
+
+function hrtime(prev) {
+  if (prev) {
+    var delta = process.hrtime(prev);
+    return (delta[0] * 1000) + (delta[1] / 1e6);
+  }
+
+  return process.hrtime();
 }
 
 /**

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -64,4 +64,24 @@ describe('debug', function () {
     });
   });
 
+  describe('timed sections', function () {
+    var log;
+
+    beforeEach(function () {
+      debug.enable('test');
+      log = debug('test');
+    });
+
+    context('with log function', function () {
+      it('times a critical section', function () {
+        log.log = sinon.spy();
+
+        var section = log.begin('a critical section');
+        log('something inside the section');
+        section.end();
+
+        expect(log.log).to.have.been.calledThrice;
+      });
+    });
+  });
 });


### PR DESCRIPTION
This adds timed sections, similar to `console.time()` and `console.timeEnd()`.

I understand completely if this isn't something you guys want added. However, it should be a non-breaking change.

If it _is_ something you're interested in, I'll add docs to the readme :)

This works both in the browser and in Node.

---

Usage:

```javascript
const debug = require('debug')('foo:bar');

const sec = debug.begin('section 1');

sec.mark('this is a marker');
sec.mark('it, too, shows the delta from the beginning of the section');

sec.end('finally, we can end the section');
// or simply
sec.end();
```
<img width="602" alt="screen shot 2017-08-09 at 2 18 25 am" src="https://user-images.githubusercontent.com/885648/29114409-115911f2-7ca9-11e7-91e8-349797fde816.png">

As you'd expect, `.mark()` is entirely optional, and the arguments to `.mark()` and `.end()` are optional as well.

Arguments passed to `.mark()` and `.end()` are separated from the `.begin()` text with `::`, and all formatting parameters are preserved as you'd expect - even in the browser:

<img width="1504" alt="screen shot 2017-08-09 at 2 19 27 am" src="https://user-images.githubusercontent.com/885648/29114445-39609076-7ca9-11e7-8347-9e169f1fda2f.png">