### PR TITLE
Hide tty date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # debug
-[![Build Status](https://travis-ci.org/visionmedia/debug.svg?branch=master)](https://travis-ci.org/visionmedia/debug)  [![Coverage Status](https://coveralls.io/repos/github/visionmedia/debug/badge.svg?branch=master)](https://coveralls.io/github/visionmedia/debug?branch=master)  [![Slack](https://visionmedia-community-slackin.now.sh/badge.svg)](https://visionmedia-community-slackin.now.sh/) [![OpenCollective](https://opencollective.com/debug/backers/badge.svg)](#backers) 
+[![Build Status](https://travis-ci.org/visionmedia/debug.svg?branch=master)](https://travis-ci.org/visionmedia/debug)  [![Coverage Status](https://coveralls.io/repos/github/visionmedia/debug/badge.svg?branch=master)](https://coveralls.io/github/visionmedia/debug?branch=master)  [![Slack](https://visionmedia-community-slackin.now.sh/badge.svg)](https://visionmedia-community-slackin.now.sh/) [![OpenCollective](https://opencollective.com/debug/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/debug/sponsors/badge.svg)](#sponsors)
 
 <img width="647" src="https://user-images.githubusercontent.com/71256/29091486-fa38524c-7c37-11e7-895f-e7ec8e1039b6.png">
@@ -149,6 +149,7 @@ change the behavior of the debug logging:
 | `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
 | `DEBUG_DEPTH` | Object inspection depth. |
 | `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
+| `DEBUG_HIDE_TTY_DATE` | Hide date from debug output on TTY. |
 
 
 __Note:__ The environment variables beginning with `DEBUG_` end up being
@@ -269,7 +270,7 @@ enabled or disabled.
  - TJ Holowaychuk
  - Nathan Rajlich
  - Andrew Rhyne
- 
+
 ## Backers
 
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/debug#backer)]

--- a/src/node.js
+++ b/src/node.js
@@ -55,6 +55,8 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
     .toLowerCase()
     .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
 
+    console.log('key', key);
+
   // coerce string value into JS value
   var val = process.env[key];
   if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
@@ -113,8 +115,15 @@ function formatArgs(args) {
     args[0] = prefix + args[0].split('\n').join('\n' + prefix);
     args.push(colorCode + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
   } else {
-    args[0] = new Date().toISOString()
-      + ' ' + name + ' ' + args[0];
+    args[0] = getDate() + name + ' ' + args[0];
+  }
+}
+
+function getDate() {
+  if ('hideTtyDate' in this.inspectOpts && this.inspectOpts.hideTtyDate) {
+    return '';
+  } else {
+    return new Date().toISOString() + ' ';
   }
 }
 

--- a/src/node.js
+++ b/src/node.js
@@ -55,8 +55,6 @@ exports.inspectOpts = Object.keys(process.env).filter(function (key) {
     .toLowerCase()
     .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
 
-    console.log('key', key);
-
   // coerce string value into JS value
   var val = process.env[key];
   if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
@@ -120,11 +118,7 @@ function formatArgs(args) {
 }
 
 function getDate() {
-<<<<<<< Updated upstream
-  if ('hideTtyDate' in this.inspectOpts && this.inspectOpts.hideTtyDate) {
-=======
   if ('hideTtyDate' in exports.inspectOpts && exports.inspectOpts.hideTtyDate) {
->>>>>>> Stashed changes
     return '';
   } else {
     return new Date().toISOString() + ' ';

--- a/src/node.js
+++ b/src/node.js
@@ -23,7 +23,7 @@ exports.useColors = useColors;
  * Colors.
  */
 
-exports.colors = [ 6, 2, 3, 4, 5, 1 ];
+exports.colors = [6, 2, 3, 4, 5, 1];
 
 try {
   var supportsColor = require('supports-color');
@@ -82,7 +82,7 @@ function useColors() {
  * Map %o to `util.inspect()`, all on a single line.
  */
 
-exports.formatters.o = function(v) {
+exports.formatters.o = function (v) {
   this.inspectOpts.colors = this.useColors;
   return util.inspect(v, this.inspectOpts)
     .replace(/\s*\n\s*/g, ' ');
@@ -92,7 +92,7 @@ exports.formatters.o = function(v) {
  * Map %o to `util.inspect()`, allowing multiple lines if needed.
  */
 
-exports.formatters.O = function(v) {
+exports.formatters.O = function (v) {
   this.inspectOpts.colors = this.useColors;
   return util.inspect(v, this.inspectOpts);
 };
@@ -120,7 +120,11 @@ function formatArgs(args) {
 }
 
 function getDate() {
+<<<<<<< Updated upstream
   if ('hideTtyDate' in this.inspectOpts && this.inspectOpts.hideTtyDate) {
+=======
+  if ('hideTtyDate' in exports.inspectOpts && exports.inspectOpts.hideTtyDate) {
+>>>>>>> Stashed changes
     return '';
   } else {
     return new Date().toISOString() + ' ';
@@ -170,7 +174,7 @@ function load() {
  * differently for a particular `debug` instance.
  */
 
-function init (debug) {
+function init(debug) {
   debug.inspectOpts = {};
 
   var keys = Object.keys(exports.inspectOpts);


### PR DESCRIPTION
This option is very needed when running Node on systems that already provides time stamps such as Heroku, PM2, systemd...

Solves #453