### PR TITLE
Ability to suppress timestamps when useColors is false - maintains backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ change the behavior of the debug logging:
 | `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
 | `DEBUG_DEPTH` | Object inspection depth. |
 | `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
+| `DEBUG_TIMESTAMPS` | Turns off timestamps when DEBUG_COLORS is false. |
 
 
 __Note:__ The environment variables beginning with `DEBUG_` end up being

--- a/src/debug.js
+++ b/src/debug.js
@@ -118,6 +118,7 @@ function createDebug(namespace) {
   debug.namespace = namespace;
   debug.enabled = exports.enabled(namespace);
   debug.useColors = exports.useColors();
+  debug.printTimestamp = exports.printTimestamp ? exports.printTimestamp() : true;
   debug.color = selectColor(namespace);
   debug.destroy = destroy;
 

--- a/src/node.js
+++ b/src/node.js
@@ -18,6 +18,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.printTimestamp = printTimestamp;
 
 /**
  * Colors.
@@ -43,7 +44,7 @@ try {
 /**
  * Build up the default `inspectOpts` object from the environment variables.
  *
- *   $ DEBUG_COLORS=no DEBUG_DEPTH=10 DEBUG_SHOW_HIDDEN=enabled node script.js
+ *   $ DEBUG_COLORS=no DEBUG_DEPTH=10 DEBUG_SHOW_HIDDEN=enabled DEBUG_TIMESTAMPS=no node script.js
  */
 
 exports.inspectOpts = Object.keys(process.env).filter(function (key) {
@@ -77,6 +78,17 @@ function useColors() {
 }
 
 /**
+ * Print timestamps when useColours() is false. This flag enables 
+ * timestamps to be turned off when useColours() is false. 
+ */
+
+function printTimestamp() {
+  return 'timestamps' in exports.inspectOpts
+    ? Boolean(exports.inspectOpts.timestamps)
+    : true;
+}
+
+/**
  * Map %o to `util.inspect()`, all on a single line.
  */
 
@@ -104,6 +116,7 @@ exports.formatters.O = function(v) {
 function formatArgs(args) {
   var name = this.namespace;
   var useColors = this.useColors;
+  var printTimestamp = this.printTimestamp;
 
   if (useColors) {
     var c = this.color;
@@ -112,9 +125,11 @@ function formatArgs(args) {
 
     args[0] = prefix + args[0].split('\n').join('\n' + prefix);
     args.push(colorCode + 'm+' + exports.humanize(this.diff) + '\u001b[0m');
-  } else {
+  } else if (printTimestamp) {
     args[0] = new Date().toISOString()
       + ' ' + name + ' ' + args[0];
+  } else {
+    args[0] = name + ' ' + args[0];
   }
 }
 


### PR DESCRIPTION
To provide the option to disable printing of timestamps when userColours is false.  Will maintain the default behaviour if its not set for backwards compatibility. 

Reasons for this change have been mentioned in some comments already -  the need to disable the double logging of timestamps in systems that already print timestamps. 

https://travis-ci.org/rynmsh/debug