### PR TITLE
Disable colors in Edge and Internet Explorer

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -49,6 +49,11 @@ function useColors() {
     return true;
   }
 
+  // Internet Explorer and Edge do not support colors.
+  if (typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/(edge|trident)\/(\d+)/)) {
+    return false;
+  }
+
   // is webkit? http://stackoverflow.com/a/16459606/376773
   // document is undefined in react-native: https://github.com/facebook/react-native/pull/1632
   return (typeof document !== 'undefined' && document.documentElement && document.documentElement.style && document.documentElement.style.WebkitAppearance) ||


### PR DESCRIPTION
Fixes https://github.com/visionmedia/debug/issues/417

Both Internet Explorer and Edge report "AppleWebKit" in their `User-Agent`, so the current  `useColors()` function in `src/browser.js` returns `true` (check my rationale about this [here](https://github.com/visionmedia/debug/issues/417#issuecomment-323596192). But in fact, Edge and Internet Explorer do not support colors in the console.

This PR checks whether the browser is Edge/IE and, if so, makes `useColors()` return false.

**NOTE:** A good project for detecting browsers is [bowser](https://www.npmjs.com/package/bowser). In includes nice [examples](https://github.com/lancedikson/bowser/blob/master/src/useragents.js) of how the `User-Agent` of many browsers looks like.