### PR TITLE
Allow function to be passed & executed if enabled

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -221,5 +221,6 @@ function enabled(name) {
 
 function coerce(val) {
   if (val instanceof Error) return val.stack || val.message;
+  if (typeof val === 'function') return val();
   return val;
 }


### PR DESCRIPTION
**Title:** Optimised debug information collection

**Use Case:** Sometimes producing debug output is extra intensive on resource. If it won't be displayed (debug environment var not set or doesn't match) there is no point in generating the debug info. Such heavy debug information could be binding prepared queries params to produce the actual query for debug, etc. For this reason, having the ability to wrap inside a callback would improve any such performance issue by only executing debug info when it will be displayed.

**Example:**

```
// Normal behaviour.
debug("Hello World"); 

// Only if this should be displayed will it execute the callback
debug(function() {
       return mysql.format(sql,values);
});
```

This was further discussed here: https://github.com/visionmedia/debug/issues/370#issuecomment-294376790