### PR TITLE
fix: treat * as wildcard for `enabled()`

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -157,8 +157,8 @@ module.exports = function setup(env) {
   function enable(namespaces) {
     createDebug.save(namespaces);
 
-    createDebug.names = [];
-    createDebug.skips = [];
+    createDebug.names = createDebug.names || [];
+    createDebug.skips = createDebug.skips || [];
 
     var i;
     var split = (typeof namespaces === 'string' ? namespaces : '').split(/[\s,]+/);
@@ -187,7 +187,7 @@ module.exports = function setup(env) {
    */
 
   function disable() {
-    createDebug.enable('');
+    createDebug.names = [];
   }
 
   /**
@@ -200,7 +200,7 @@ module.exports = function setup(env) {
 
   function enabled(name) {
     if (name[name.length - 1] === '*') {
-      return true;
+      return createDebug.names.length > 0;
     }
     var i, len;
     for (i = 0, len = createDebug.skips.length; i < len; i++) {

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -64,4 +64,23 @@ describe('debug', function () {
     });
   });
 
+   context('disable()', function () {
+     beforeEach(function () {
+       debug.enable('*');
+       debug('should disable')
+     });
+
+     it('disable itself', function () {
+       debug.disable('*');
+       expect(debug.enabled('*')).to.be.false;
+     });
+   });
+
+   it('should avoid namespace conflict', function () {
+     debug.enable('test1*');
+     debug.enable('test2*');
+
+     expect(debug('test1').enabled).to.be.true;
+     expect(debug('test2').enabled).to.be.true;
+   });
 });


### PR DESCRIPTION
fix #495