### PR TITLE
instance extends feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,20 @@ error('now goes to stdout via console.info');
 log('still goes to stdout, but via console.info now');
 ```
 
+## Extend
+You can simply extend debugger 
+```js
+const log = require('debug')('auth');
+
+//creates new debug instance with extended namespace
+const logSign = log.extend('sign');
+const logLogin = log.extend('login');
+
+log('hello'); // auth hello
+logSign('hello'); //auth:sign hello
+logLogin('hello'); //auth:login hello
+```
+
 ## Set dynamically
 
 You can also enable debug dynamically by calling the `enable()` method :

--- a/src/common.js
+++ b/src/common.js
@@ -148,11 +148,7 @@ module.exports = function setup(env) {
   }
 
   function extend (namespace, delimiter) {
-    if(typeof delimiter === 'undefined') {
-      delimiter = ':';
-    }
-
-    return createDebug(this.namespace + delimiter + namespace);
+    return createDebug(this.namespace + (delimiter || ':') + namespace);
   }
 
   /**

--- a/src/common.js
+++ b/src/common.js
@@ -148,7 +148,7 @@ module.exports = function setup(env) {
   }
 
   function extend (namespace, delimiter) {
-    return createDebug(this.namespace + (delimiter || ':') + namespace);
+    return createDebug(this.namespace + (typeof delimiter !== 'undefined' ? delimiter : ':') + namespace);
   }
 
   /**

--- a/src/common.js
+++ b/src/common.js
@@ -123,6 +123,7 @@ module.exports = function setup(env) {
     debug.useColors = createDebug.useColors();
     debug.color = selectColor(namespace);
     debug.destroy = destroy;
+    debug.extend = extend;
     //debug.formatArgs = formatArgs;
     //debug.rawLog = rawLog;
 
@@ -144,6 +145,14 @@ module.exports = function setup(env) {
     } else {
       return false;
     }
+  }
+
+  function extend (namespace, delimiter) {
+    if(typeof delimiter === 'undefined') {
+      delimiter = ':';
+    }
+
+    return createDebug(this.namespace + delimiter + namespace);
   }
 
   /**

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -64,4 +64,30 @@ describe('debug', function () {
     });
   });
 
+
+  describe('extend namespace', function () {
+    var log;
+
+    beforeEach(function () {
+      debug.enable('foo');
+      log = debug('foo');
+    });
+
+    it('should extend namespace', function () {
+      var logBar = log.extend('bar');
+      expect(logBar.namespace).to.be.equal('foo:bar');
+    });
+
+    it('should extend namespace with custom delimiter', function () {
+      var logBar = log.extend('bar', '--');
+      expect(logBar.namespace).to.be.equal('foo--bar');
+    });
+
+    it('should extend namespace with empty delimiter', function () {
+      var logBar = log.extend('bar', '');
+      expect(logBar.namespace).to.be.equal('foobar');
+    });
+
+  });
+
 });


### PR DESCRIPTION
This adds the ability to dynamically create "child-loggers"
This is just add-on, not breaking-change

Example

```js
const debug = require('debug');

const log = debug('auth');
const logSign = log.extend('sign');
const logLogin = log.extend('login');

log('hello'); // auth hello
logSign('hello'); //auth:sign hello
logLogin('hello'); //auth:login hello
```

It's useful when there is one class with large functions that need to be divided into different namespace but at the same time be able to easily log all of them