### PR TITLE
Provide a general millisecond diff

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -63,9 +63,9 @@ module.exports = function setup(env) {
    * @api public
    */
 
+  var prevTime;
+  
   function createDebug(namespace) {
-    var prevTime;
-
     function debug() {
       // disabled?
       if (!debug.enabled) return;


### PR DESCRIPTION
This is more useful than per namespace ms diff

This way you can detect hotspots, blocking code, etc.