### PR TITLE
fix memory leaks caused by acitive debug instances when a debug target is not enabled

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -131,8 +131,10 @@ module.exports = function setup(env) {
       createDebug.init(debug);
     }
 
-    createDebug.instances.push(debug);
-
+    if (!debug.enabled) {
+      createDebug.instances.push(debug);
+    }
+   
     return debug;
   }
 

--- a/src/common.js
+++ b/src/common.js
@@ -131,7 +131,7 @@ module.exports = function setup(env) {
       createDebug.init(debug);
     }
 
-    if (!debug.enabled) {
+    if (debug.enabled) {
       createDebug.instances.push(debug);
     }
    


### PR DESCRIPTION
Recently, I've experienced serious memory leaks problem when I use [nsqjs](https://github.com/dudleycarr/nsqjs). I debug it and find the root of memory leak problem in the end.

[nsqjs](https://github.com/dudleycarr/nsqjs) uses debug@3.0.1, and it doesn't destroy active debug instance when the debug target is not enabled. `debug` module will keep the debug instances active when the debug target is not enabled. I think it is not a good idea. In my opinion, it should't have side effects when it is disabled.

I comment out `createDebug.instances.push(debug);`(https://github.com/visionmedia/debug/blob/master/src/common.js#L134)  and then I get the image as follows.

![](http://7xp9v5.com1.z0.glb.clouddn.com/memory-leak-with-debug.jpg)

The memory leak is gone.
