### PR TITLE
Add option to hide namespace in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ change the behavior of the debug logging:
 | `DEBUG_COLORS`| Whether or not to use colors in the debug output. |
 | `DEBUG_DEPTH` | Object inspection depth.                    |
 | `DEBUG_SHOW_HIDDEN` | Shows hidden properties on inspected objects. |
+| `DEBUG_HIDE_NAMESPACE` | Hide namespace from debug output.  |
 
 
 __Note:__ The environment variables beginning with `DEBUG_` end up being

--- a/src/node.js
+++ b/src/node.js
@@ -80,6 +80,11 @@ function useColors() {
  */
 
 function formatArgs(args) {
+  if (exports.inspectOpts.hideNamespace) {
+    args[0] = getDate() + ' ' + args[0];
+    return;
+  }
+
   var name = this.namespace;
   var useColors = this.useColors;
 

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -85,26 +85,37 @@ describe('debug', function () {
     });
   });
 
-  context('when hiding namespace', function () {
-    beforeEach(function () {
-      process.env.DEBUG_HIDE_NAMESPACE = true;
+  context('toggle namespace in logs', function () {
+    it('produces the log with namespace (default behavior)', function () {
       process.env.DEBUG_HIDE_DATE = true;
+      withDebug(function(debugInstance) {
+        debug = debugInstance;
+        debug.enable('some-namespace');
+        log = debug('some-namespace');
+      });
+      log.log = sinon.spy();
+      log('some message');
+      expect(log.log.getCall(0).args[0].trim()).to.match(/some\-namespace/);
+      expect(log.log.getCall(0).args[0].trim()).to.match(/some message/);
+      delete process.env.DEBUG_HIDE_DATE;
+    });
+
+    it('produces the log without namespace when DEBUG_HIDE_NAMESPACE is set', function () {
+      process.env.DEBUG_HIDE_DATE = true;
+      process.env.DEBUG_HIDE_NAMESPACE = true;
+
       withDebug(function(debugInstance) {
         debug = debugInstance;
         debug.enable('test');
         log = debug('test');
       });
-    });
 
-    afterEach(function () {
-      delete process.env.DEBUG_HIDE_NAMESPACE;
-      delete process.env.DEBUG_HIDE_DATE;
-    });
-
-    it('produces the log without namespace', function () {
       log.log = sinon.spy();
       log('some message');
       expect(log.log.getCall(0).args[0].trim()).to.equal('some message');
+
+      delete process.env.DEBUG_HIDE_DATE;
+      delete process.env.DEBUG_HIDE_NAMESPACE;
     });
   });
 });

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -9,6 +9,14 @@ var chai
   , log;
 
 
+if (typeof module !== 'undefined') {
+  chai = require('chai');
+  expect = chai.expect;
+  sinon = require('sinon');
+  sinonChai = require('sinon-chai');
+  chai.use(sinonChai);
+}
+
 describe('debug', function () {
   function withDebug(cb) {
     function requireDebug() {
@@ -19,16 +27,6 @@ describe('debug', function () {
 
     cb(requireDebug());
   }
-
-  before(function () {
-    if (typeof module !== 'undefined') {
-      chai = require('chai');
-      expect = chai.expect;
-      sinon = require('sinon');
-      sinonChai = require("sinon-chai");
-      chai.use(sinonChai);
-    }
-  });
 
   context('start up', function () {
     beforeEach(function () {

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -15,14 +15,18 @@ if (typeof module !== 'undefined') {
   sinon = require('sinon');
   sinonChai = require('sinon-chai');
   chai.use(sinonChai);
+  debug = require('../src/index');
 }
 
 describe('debug', function () {
   function withDebug(cb) {
     function requireDebug() {
-      delete require.cache[require.resolve('../src/index')];
-      delete require.cache[require.resolve('../src/node.js')];
-      return require('../src/index');
+      if (typeof module !== 'undefined') {
+        delete require.cache[require.resolve('../src/index')];
+        delete require.cache[require.resolve('../src/node.js')];
+        return require('../src/index');
+      }
+      return debug;
     }
 
     cb(requireDebug());
@@ -86,6 +90,11 @@ describe('debug', function () {
   });
 
   context('toggle namespace in logs', function () {
+    // namespace hiding relies on environment variable and does not apply to browser
+    if (typeof process === 'undefined') {
+      return;
+    }
+
     it('produces the log with namespace (default behavior)', function () {
       process.env.DEBUG_HIDE_DATE = true;
       withDebug(function(debugInstance) {


### PR DESCRIPTION
Our log collector expects the output to be of some format (across systems, that write logs) and now the only thing I can't control is the namespace, prepended to each line. 

It's enabled by default, passing environment variable allows hiding it.

PR contains tests that cover default behavior (namespace + log) and the new feature.