### PR TITLE
Adding TVMLKit support

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -169,11 +169,8 @@ function load() {
 function localstorage() {
   try {
     // TVMLKit (Apple TV JS Runtime) does not have a window object, just localStorage in the global context
-    if (typeof window === 'undefined' && typeof navigationDocument !== 'undefined') {
-      return localStorage;
-    }
-
-    return window.localStorage;
+    // The Browser also has localStorage in the global context.
+    return localStorage;
   } catch (e) {}
 }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -129,7 +129,7 @@ function save(namespaces) {
     if (null == namespaces) {
       exports.storage.removeItem('debug');
     } else {
-      exports.storage.debug = namespaces;
+      exports.storage.setItem('debug', namespaces);
     }
   } catch(e) {}
 }
@@ -144,7 +144,7 @@ function save(namespaces) {
 function load() {
   var r;
   try {
-    r = exports.storage.debug;
+    r = exports.storage.getItem('debug');
   } catch(e) {}
 
   // If debug isn't set in LS, and we're in Electron, try to load $DEBUG
@@ -168,6 +168,11 @@ function load() {
 
 function localstorage() {
   try {
+    // TVMLKit (Apple TV JS Runtime) does not have a window object, just localStorage in the global context
+    if (typeof window === 'undefined' && typeof navigationDocument !== 'undefined') {
+      return localStorage;
+    }
+
     return window.localStorage;
   } catch (e) {}
 }


### PR DESCRIPTION
Apple TV has a JS runtime that allows you to built apps with Javascript.  There are some intricacies of it though. There is no `window` object and you need to access Storage with the `getItem` and `setItem` functions instead of directly accessing properties on the storage object.

This PR adds support for TVMLKit by simply checking if we are in a TVMLKit environment and returning the proper `localStorage` object and by using the item getter/setter calls for the `debug` value.

Just adding some docs related to the storage API and compatibility with `getItem`/`setItem`
https://developer.mozilla.org/en-US/docs/Web/API/Storage/LocalStorage
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
