### PR TITLE
Add option to disable colors in the browser

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -42,26 +42,29 @@ try {
  *
  *   $ DEBUG_COLORS=no DEBUG_DEPTH=10 DEBUG_SHOW_HIDDEN=enabled node script.js
  */
+exports.loadInspectOpts = function () {
+  exports.inspectOpts = Object.keys(process.env).filter(function (key) {
+    return /^debug_/i.test(key);
+  }).reduce(function (obj, key) {
+    // camel-case
+    var prop = key
+      .substring(6)
+      .toLowerCase()
+      .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
 
-exports.inspectOpts = Object.keys(process.env).filter(function (key) {
-  return /^debug_/i.test(key);
-}).reduce(function (obj, key) {
-  // camel-case
-  var prop = key
-    .substring(6)
-    .toLowerCase()
-    .replace(/_([a-z])/g, function (_, k) { return k.toUpperCase() });
+    // coerce string value into JS value
+    var val = process.env[key];
+    if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
+    else if (/^(no|off|false|disabled)$/i.test(val)) val = false;
+    else if (val === 'null') val = null;
+    else val = Number(val);
 
-  // coerce string value into JS value
-  var val = process.env[key];
-  if (/^(yes|on|true|enabled)$/i.test(val)) val = true;
-  else if (/^(no|off|false|disabled)$/i.test(val)) val = false;
-  else if (val === 'null') val = null;
-  else val = Number(val);
+    obj[prop] = val;
+    return obj;
+  }, {});
+};
 
-  obj[prop] = val;
-  return obj;
-}, {});
+exports.loadInspectOpts();
 
 /**
  * Is stdout a TTY? Colored output is enabled when `true`.

--- a/test/debug_spec.js
+++ b/test/debug_spec.js
@@ -64,4 +64,24 @@ describe('debug', function () {
     });
   });
 
+  describe('colors', function () {
+    var log;
+
+    it('should default to true', function () {
+      console.log(debug.useColors());
+      expect(debug.useColors()).to.be.true;
+    });
+
+    it('can turn off explicitly', function () {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('debug_colors', false);
+      } else if (typeof process !== 'undefined' && 'env' in process) {
+        process.env.DEBUG_COLORS = 'false';
+        debug.loadInspectOpts();
+      }
+
+      expect(debug.useColors()).to.be.false;
+    });
+  });
+
 });


### PR DESCRIPTION
Add an option to allow you to disable colors in the browser.

## Why

We use debug in a few browser projects. Sometimes the output of the console ends up in a text file, and the formatting control characters make it difficult to grok.

## Usage

`localStorage.setItem('debug_colors', false);`

## Notes

I had to add an option to reload the `inspectOpts` in the node environment. This is only used for the tests. Perhaps there is a better way, but I did not find one.