### PR TITLE
DEBUG_USE_MICROSECONDS=Y DEBUG=* node ./examples/node/useMicroseconds.js

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "module",
+      "sources": [ "./src/module.c" ]
+    }
+  ]
+}

--- a/examples/node/useMicroseconds.js
+++ b/examples/node/useMicroseconds.js
@@ -1,0 +1,18 @@
+/*
+ * node-gyp configure build
+ *
+ * DEBUG_USE_MICROSECONDS=Y DEBUG=* node ./examples/node/useMicroseconds.js
+ * DEBUG=* node ./examples/node/useMicroseconds.js
+ */
+
+const debug = require('../../')('use:µs');
+
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+debug('the ∆ is')
+setTimeout(() => debug('the ∆ is'), 11000)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "log",
     "debugger"
   ],
+  "scripts": {
+    "test": "./node_modules/mocha/bin/_mocha"
+  },
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net> (http://n8.io)",

--- a/src/browser.js
+++ b/src/browser.js
@@ -8,6 +8,7 @@ exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
 exports.storage = localstorage();
+exports.now = function () { return +new Date() }
 
 /**
  * Colors.

--- a/src/common.js
+++ b/src/common.js
@@ -73,7 +73,7 @@ module.exports = function setup(env) {
       var self = debug;
 
       // set `diff` timestamp
-      var curr = +new Date();
+      var curr = createDebug.now() 
       var ms = curr - (prevTime || curr);
       self.diff = ms;
       self.prev = prevTime;

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,13 @@ if (typeof process === 'undefined' || process.type === 'renderer' || process.bro
   module.exports = require('./browser.js');
 } else {
   module.exports = require('./node.js');
+  if (process.env.DEBUG_USE_MICROSECONDS) {
+    var humanizeMs = module.exports.humanize
+    module.exports.humanize = delta => {
+      if (delta > 10000) {
+        return humanizeMs((delta + 500) / 1000)
+      }
+      return `${delta}µs`
+    }
+  }
 }

--- a/src/module.c
+++ b/src/module.c
@@ -1,0 +1,49 @@
+#include <node_api.h>   /* n-api */
+#include <sys/time.h>   /* gettimeofday, timeval (for timestamp in microseconds) */
+
+long long int now () {
+  struct timeval t_us;
+  long long int us;
+
+  if (!gettimeofday(&t_us, NULL)) {
+    us = ((long long int) t_us.tv_sec) * 1000000ll +
+          (long long int) t_us.tv_usec;
+  }
+  else return -1ll;
+
+  return us;
+}
+
+napi_value MyFunction (napi_env env, napi_callback_info info) {
+  napi_status status;
+
+  /* Convert to JS Number the current time in microseconds.
+   */
+  long long int number = now();
+  napi_value myNumber;
+  status = napi_create_int64(env, number, &myNumber);
+  if (status != napi_ok) {
+    napi_throw_error(env, NULL, "Unable to create return value");
+  }
+
+  return myNumber;
+}
+
+napi_value Init (napi_env env, napi_value exports) {
+  napi_status status;
+  napi_value fn;
+
+  status = napi_create_function(env, NULL, 0, MyFunction, NULL, &fn);
+  if (status != napi_ok) {
+    napi_throw_error(env, NULL, "Unable to wrap native function");
+  }
+
+  status = napi_set_named_property(env, exports, "gettimeofday", fn);
+  if (status != napi_ok) {
+    napi_throw_error(env, NULL, "Unable to populate exports");
+  }
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/src/node.js
+++ b/src/node.js
@@ -15,6 +15,8 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.now = process.env.DEBUG_USE_MICROSECONDS ?
+  require('../build/Release/module').gettimeofday : () => { return +new Date() }
 
 /**
  * Colors.


### PR DESCRIPTION
Add an option to use microseconds in timestamps. Tested on macOS 10.12.6 and Ubuntu 16.04 LTS. Sample output:

```
alec@alec-MS-7596 ~/process/debug (master) $ DEBUG_USE_MICROSECONDS=Y DEBUG=* node ./examples/node/useMicroseconds.js 
  use:µs the ∆ is +0µs
  use:µs the ∆ is +1366µs
  use:µs the ∆ is +110µs
  use:µs the ∆ is +31µs
  use:µs the ∆ is +36µs
  use:µs the ∆ is +24µs
  use:µs the ∆ is +23µs
  use:µs the ∆ is +23µs
(node:5403) Warning: N-API is an experimental feature and could change at any time.
  use:µs the ∆ is +11s
alec@alec-MS-7596 ~/process/debug (master) $ DEBUG=* node ./examples/node/useMicroseconds.js 
  use:µs the ∆ is +0ms
  use:µs the ∆ is +2ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +0ms
  use:µs the ∆ is +11s
alec@alec-MS-7596 ~/process/debug (master) $ npm test

> debug@3.1.0 test /home/alec/process/debug
> ./node_modules/mocha/bin/_mocha



  debug
    ✓ passes a basic sanity check
    ✓ allows namespaces to be a non-string value
    with log function
      ✓ uses it
    custom functions
      with log function
        ✓ uses it


  4 passing (9ms)

```