### PR TITLE
Fix browserify and supply alternative unpkg entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dist: dist/debug.js dist/test.js
 .INTERMEDIATE: dist/debug.es6.js
 dist/debug.es6.js: src/*.js
 	@mkdir -p dist
-	browserify --standalone debug $< > $@
+	browserify --standalone debug . > $@
 
 dist/debug.js: dist/debug.es6.js
 	@mkdir -p dist

--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",
-  "browser": "./dist/debug.js"
+  "browser": "./src/browser.js",
+  "unpkg": "./dist/debug.js"
 }


### PR DESCRIPTION
Closes #606.
Ref #603.

This restores Browserify functionality when `debug` is used as a nested module. It also fixes the unpkg use case (though in reality there should be a better, more standard way to do this).

However, it's the least intrusive way to fix both problems. I can't guarantee that the unpkg solution works, but users should be pinning versions anyway and not using `debug@*` on live sites.

cc @mjackson - if you have any input as to how to support unpkg in a less domain-specific way, that'd be great.