### PR TITLE
feat: Return namespaces string when invoking disable()

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,24 @@ $ DEBUG=foo node -e 'var dbg = require("debug"); dbg.enable("bar"); console.log(
 => false
 ```
 
+`disable()`
+
+Will disable all namespaces. The functions returns the namespaces currently
+enabled (and skipped). This can be useful if you want to disable debugging
+temporarily without knowing what was enabled to begin with.
+
+For example:
+
+```js
+let debug = require('debug');
+debug.enable('foo:*,-foo:bar');
+let namespaces = debug.disable();
+debug.enable(namespaces);
+```
+
+Note: There is no guarantee that the string will be identical to the initial
+enable string, but semantically they will be identical.
+
 ## Checking whether a debug target is enabled
 
 After you've created a debug instance, you can determine whether or not it is

--- a/src/common.js
+++ b/src/common.js
@@ -187,10 +187,16 @@ function setup(env) {
 	/**
 	* Disable debug output.
 	*
+	* @return {String} namespaces
 	* @api public
 	*/
 	function disable() {
+		const namespaces = [
+			...createDebug.names.map(toNamespace),
+			...createDebug.skips.map(toNamespace).map(namespace => '-' + namespace)
+		].join(',');
 		createDebug.enable('');
+		return namespaces;
 	}
 
 	/**
@@ -221,6 +227,19 @@ function setup(env) {
 		}
 
 		return false;
+	}
+
+	/**
+	* Convert regexp to namespace
+	*
+	* @param {RegExp} regxep
+	* @return {String} namespace
+	* @api private
+	*/
+	function toNamespace(regexp) {
+		return regexp.toString()
+			.substring(2, regexp.toString().length - 2)
+			.replace(/\.\*\?$/, '*');
 	}
 
 	/**

--- a/test.js
+++ b/test.js
@@ -81,4 +81,43 @@ describe('debug', () => {
 			expect(logBar.namespace).to.be.equal('foobar');
 		});
 	});
+
+	describe('rebuild namespaces string (disable)', () => {
+		it('handle names, skips, and wildcards', () => {
+			debug.enable('test,abc*,-abc');
+			const namespaces = debug.disable();
+			expect(namespaces).to.equal('test,abc*,-abc');
+		});
+
+		it('handles empty', () => {
+			debug.enable('');
+			const namespaces = debug.disable();
+			expect(namespaces).to.equal('');
+			expect(debug.names).to.deep.equal([]);
+			expect(debug.skips).to.deep.equal([]);
+		});
+
+		it('handles all', () => {
+			debug.enable('*');
+			const namespaces = debug.disable();
+			expect(namespaces).to.equal('*');
+		});
+
+		it('handles skip all', () => {
+			debug.enable('-*');
+			const namespaces = debug.disable();
+			expect(namespaces).to.equal('-*');
+		});
+
+		it('names+skips same with new string', () => {
+			debug.enable('test,abc*,-abc');
+			const oldNames = [...debug.names];
+			const oldSkips = [...debug.skips];
+			const namespaces = debug.disable();
+			expect(namespaces).to.equal('test,abc*,-abc');
+			debug.enable(namespaces);
+			expect(oldNames.map(String)).to.deep.equal(debug.names.map(String));
+			expect(oldSkips.map(String)).to.deep.equal(debug.skips.map(String));
+		});
+	});
 });


### PR DESCRIPTION
PR for feature request #523 

I thought about adding a new property `createDebug` which would hold the untouched string passed to `enable` but decided against it and instead let the disable deal with what it has: `names`, `skips`.

Let me know if you prefer adding an untouched namespaces string to createDebug instead or you any other changes.

Closes #523

ps: Happy Hacktoberfest