### PR TITLE
Use rollup dist bundle instead. Add esm module distribute for rollup ecosystem.  (#468)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,12 @@
         "targets": {
           "chrome": "58",
           "ie": "8"
-        }
+        },
+        "exclude": [
+          "transform-typeof-symbol",
+          "transform-function-name",
+          "transform-classes"
+        ]
       }
     ]
   ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for debug
+// Project: https://github.com/visionmedia/debug
+// Definitions by: Seon-Wook Park <https://github.com/swook>
+//                 Gal Talmor <https://github.com/galtalmor>
+//                 John McLaughlin <https://github.com/zamb3zi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var debug: debug.IDebug;
+
+export = debug;
+export as namespace debug;
+
+declare namespace debug {
+    export interface IDebug {
+        (namespace: string): debug.IDebugger,
+        coerce: (val: any) => any,
+        disable: () => void,
+        enable: (namespaces: string) => void,
+        enabled: (namespaces: string) => boolean,
+
+        names: RegExp[],
+        skips: RegExp[],
+
+        formatters: IFormatters
+    }
+
+    export interface IFormatters {
+        [formatter: string]: Function
+    }
+
+    export interface IDebugger {
+        (formatter: any, ...args: any[]): void;
+
+        enabled: boolean;
+        log: Function;
+        namespace: string;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
   ],
   "files": [
     "src",
-    "dist/debug.js",
+    "dist/debug*.js",
     "LICENSE",
     "README.md"
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Nathan Rajlich <nathan@tootallnate.net> (http://n8.io)",
-    "Andrew Rhyne <rhyneandrew@gmail.com>"
+    "Andrew Rhyne <rhyneandrew@gmail.com>",
+    "Allex Wang <allex.wxn@gmail.com> (http://iallex.com)"
   ],
   "license": "MIT",
   "scripts": {
@@ -30,8 +31,7 @@
     "posttest:node": "cat ./coverage/lcov.info | coveralls",
     "pretest:browser": "npm run build",
     "test:browser": "karma start --single-run",
-    "prebuild:debug": "mkdir -p dist && browserify --standalone debug -o dist/debug.es6.js .",
-    "build:debug": "babel -o dist/debug.js dist/debug.es6.js > dist/debug.js",
+    "build:debug": "rollup -c",
     "build:test": "babel -d dist test.js",
     "build": "npm run build:debug && npm run build:test",
     "clean": "rimraf dist coverage"
@@ -43,21 +43,25 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "browserify": "14.4.0",
     "chai": "^3.5.0",
     "concurrently": "^3.1.0",
     "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
     "karma": "^2.0.0",
     "karma-chai": "^0.1.0",
-    "karma-mocha": "^1.3.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-mocha": "^1.3.0",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
     "rimraf": "^2.5.4",
+    "rollup": "^0.68.0",
+    "rollup-plugin-babel": "^4",
+    "rollup-plugin-commonjs": "^9",
+    "rollup-plugin-node-resolve": "^4.0.0",
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",
-  "browser": "./src/browser.js",
+  "module": "./dist/debug.esm.js",
+  "browser": "./dist/debug.js",
   "unpkg": "./dist/debug.js"
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "src",
     "dist/debug*.js",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "index.d.ts"
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
@@ -63,5 +64,6 @@
   "main": "./src/index.js",
   "module": "./dist/debug.esm.js",
   "browser": "./dist/debug.js",
-  "unpkg": "./dist/debug.js"
+  "unpkg": "./dist/debug.js",
+  "types": "index.d.ts"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,48 @@
+// Add by @allex_wang for rollup bundler
+
+import resolveId from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import babel from 'rollup-plugin-babel';
+
+const {version, name, author, license, dependencies} = require('./package.json');
+
+const banner = (name, short = false) => {
+	let s;
+	if (short) {
+		s = `/*! ${name} v${version} | ${license} licensed | ${author} */`;
+	} else {
+		s = `/*!
+ * ${name} v${version}
+ *
+ * @author ${author}
+ * Released under the ${license} license.
+ */`;
+	}
+	return s;
+};
+
+const plugins = [
+	resolveId(),
+	commonjs(),
+	babel({comments: false})
+];
+
+export default [
+	{
+		input: 'src/browser.js',
+		plugins,
+		external: Object.keys(dependencies), // Dependencies as external in esm dist
+		output: [
+			{file: 'dist/debug.esm.js', format: 'esm', banner: banner(name)}
+		]
+	},
+	{
+		input: 'src/browser.js',
+		plugins,
+		output: [
+			{file: 'dist/debug.js', format: 'umd', name: 'debug', banner: banner(name)}
+		]
+	}
+];
+
+/* Vim: set ft=javascript fdm=marker et ff=unix tw=80 sw=2 ts=2: */

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,7 +4,7 @@
  * This is the web browser implementation of `debug()`.
  */
 
-var exports = {};
+const exports = {};
 
 exports.log = log;
 exports.formatArgs = formatArgs;

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,6 +4,8 @@
  * This is the web browser implementation of `debug()`.
  */
 
+var exports = {};
+
 exports.log = log;
 exports.formatArgs = formatArgs;
 exports.save = save;


### PR DESCRIPTION
Use rollup dist bundle instead. Add `dist/debug.esm.js` module distribute for rollup ecosystem.  (#468)

### Use for Rollup ecosystem

```js
import resolveId from '@allex/rollup-plugin-node-resolve'

// rollup.config.js
export default {
  input: 'src/main.js',
  output: {
    file: 'dist/bundle.js',
    format: 'umd'
  },
  plugins: [
    // ...
    resolveId({
      extensions: ['.js', '.ts'],
      alias: {
        'debug': 'debug/dist/debug.esm.js',
      }
    })
  ]
  // ...
}
```