### PR TITLE
Update readme, for clarity on "*" convention in name

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ When stdout is not a TTY, `Date#toISOString()` is used, making it more useful fo
 
 ## Conventions
 
-If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser".  If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable.  You can then use it for normal output as well as debug output.
+If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser". In node, If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable.  You can then use it for normal output as well as debug output.
 
 ## Wildcards
 


### PR DESCRIPTION
The following convention only works on node currently. Noticed that while testing in browser and figured i'd update the doc.

> If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable