### PR TITLE
Remove changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-CHANGELOG.md has been deprecated moved to the Github releases pages. It will be removed in the future.
-
-Please see https://github.com/visionmedia/debug/releases for all changelogs and information pertaining
-to new releases.


### PR DESCRIPTION
It's been deprecated and we'll announce its official removal as part of 5.x.

Considering it a major change as I have no idea how people have come to depend on it over the years (hint: don't do that 💃)