### PR TITLE
fix babel compile in certain case

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -3,18 +3,18 @@
 /**
  * This is the web browser implementation of `debug()`.
  */
-
-exports.formatArgs = formatArgs;
-exports.save = save;
-exports.load = load;
-exports.useColors = useColors;
-exports.storage = localstorage();
+let browserExports = {};
+browserExports.formatArgs = formatArgs;
+browserExports.save = save;
+browserExports.load = load;
+browserExports.useColors = useColors;
+browserExports.storage = localstorage();
 
 /**
  * Colors.
  */
 
-exports.colors = [
+browserExports.colors = [
 	'#0000CC',
 	'#0000FF',
 	'#0033CC',
@@ -176,7 +176,7 @@ function formatArgs(args) {
  *
  * @api public
  */
-exports.log = console.debug || console.log || (() => {});
+browserExports.log = console.debug || console.log || (() => {});
 
 /**
  * Save `namespaces`.
@@ -187,9 +187,9 @@ exports.log = console.debug || console.log || (() => {});
 function save(namespaces) {
 	try {
 		if (namespaces) {
-			exports.storage.setItem('debug', namespaces);
+			browserExports.storage.setItem('debug', namespaces);
 		} else {
-			exports.storage.removeItem('debug');
+			browserExports.storage.removeItem('debug');
 		}
 	} catch (error) {
 		// Swallow
@@ -206,7 +206,7 @@ function save(namespaces) {
 function load() {
 	let r;
 	try {
-		r = exports.storage.getItem('debug');
+		r = browserExports.storage.getItem('debug');
 	} catch (error) {
 		// Swallow
 		// XXX (@Qix-) should we be logging these?
@@ -242,7 +242,7 @@ function localstorage() {
 	}
 }
 
-module.exports = require('./common')(exports);
+module.exports = require('./common')(browserExports);
 
 const {formatters} = module.exports;
 


### PR DESCRIPTION
some android phone can not recognize 'let', 'const'. They must be converted to 'var'.
when i use babel and babel-transform-runtime with corejs, it doesn't work.

The compiled code is like this (missing exports):

function(module, __webpack_exports__, __webpack_require__) {

"use strict";
__webpack_require__.r(__webpack_exports__);
/* WEBPACK VAR INJECTION */(function(module, process) {/* harmony import */ var _babel_runtime_corejs2_core_js_json_stringify__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime-corejs2/core-js/json/stringify */ "../../.nvm/versions/node/v8.2.1/lib/node_modules/@ies/eden/node_modules/@babel/runtime-corejs2/core-js/json/stringify.js");
/* harmony import */ var _babel_runtime_corejs2_core_js_json_stringify__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_corejs2_core_js_json_stringify__WEBPACK_IMPORTED_MODULE_0__);
/* harmony import */ var _babel_runtime_corejs2_helpers_typeof__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @babel/runtime-corejs2/helpers/typeof */ "../../.nvm/versions/node/v8.2.1/lib/node_modules/@ies/eden/node_modules/@babel/runtime-corejs2/helpers/typeof.js");
/* harmony import */ var _babel_runtime_corejs2_helpers_typeof__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_corejs2_helpers_typeof__WEBPACK_IMPORTED_MODULE_1__);
/* harmony import */ var _babel_runtime_corejs2_core_js_parse_int__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @babel/runtime-corejs2/core-js/parse-int */ "../../.nvm/versions/node/v8.2.1/lib/node_modules/@ies/eden/node_modules/@babel/runtime-corejs2/core-js/parse-int.js");
/* harmony import */ var _babel_runtime_corejs2_core_js_parse_int__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_corejs2_core_js_parse_int__WEBPACK_IMPORTED_MODULE_2__);


/* eslint-env browser */

/**
 * This is the web browser implementation of `debug()`.
 */
exports.log = log;
exports.formatArgs = formatArgs;
exports.save = save;
exports.load = load;
exports.useColors = useColors;
exports.storage = localstorage();
....
}