### PR TITLE
test: only run coveralls on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 script:
   - npm run lint
   - npm test
+  - npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npm run test:node && npm run test:browser",
     "test:node": "istanbul cover _mocha -- test.js",
     "test:browser": "karma start --single-run",
-    "posttest:node": "cat ./coverage/lcov.info | coveralls"
+    "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
     "ms": "^2.1.1"


### PR DESCRIPTION
s/posttest:node/coverage

Explicitly call coverage only from CI. This will stop the test suite
from failing on a system not configured to authenticate with
circle-ci