### PR TITLE
- use simple for loop instead of forEach

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -14,7 +14,7 @@ function setup(env) {
 	createDebug.humanize = require('ms');
 
 	for (let i = 0; i < Object.keys(env).length; i++) {
-		let key = Object.keys(env)[i];
+		const key = Object.keys(env)[i];
 		createDebug[key] = env[key];
 	}
 

--- a/src/common.js
+++ b/src/common.js
@@ -13,9 +13,10 @@ function setup(env) {
 	createDebug.enabled = enabled;
 	createDebug.humanize = require('ms');
 
-	Object.keys(env).forEach(key => {
+	for (let i = 0; i < Object.keys(env).length; i++) {
+		let key = Object.keys(env)[i];
 		createDebug[key] = env[key];
-	});
+	}
 
 	/**
 	* Active `debug` instances.


### PR DESCRIPTION
Babel is not transforming on runtime such things like forEach which is critical when a product going to be used as SaaS solution.
I have everything to transpile ES6 code, but some specific methods make me sad.
I would appreciate if you approve this small change

Thank you in advance!
