### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",
-  "browser": "./src/browser.js"
+  "browser": "./src/browser.js",
+  "engines": {
+    "node": ">=6.0" 
+  }
 }


### PR DESCRIPTION
I got bitten today because there isn't really a way to tell that debug 4.x doesn't support Node.js 4. Thanks for all your great work on this module!