### PR TITLE
Improvement of memory management for #678

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -19,8 +19,9 @@ function setup(env) {
 
 	/**
 	* Active `debug` instances.
+	* @type {Object<String, Function>}
 	*/
-	createDebug.instances = [];
+	createDebug.instances = {};
 
 	/**
 	* The currently active debug mode names, and names to skip.
@@ -62,7 +63,11 @@ function setup(env) {
 	* @api public
 	*/
 	function createDebug(namespace) {
-		let prevTime;
+		let prevTime, value = createDebug.instances[namespace];
+
+		if (!!value) {
+			return value;
+		}
 
 		function debug(...args) {
 			// Disabled?
@@ -74,8 +79,7 @@ function setup(env) {
 
 			// Set `diff` timestamp
 			const curr = Number(new Date());
-			const ms = curr - (prevTime || curr);
-			self.diff = ms;
+			self.diff = curr - (prevTime || curr);
 			self.prev = prevTime;
 			self.curr = curr;
 			prevTime = curr;
@@ -128,15 +132,14 @@ function setup(env) {
 			createDebug.init(debug);
 		}
 
-		createDebug.instances.push(debug);
+		createDebug.instances[namespace] = debug;
 
 		return debug;
 	}
 
 	function destroy() {
-		const index = createDebug.instances.indexOf(this);
-		if (index !== -1) {
-			createDebug.instances.splice(index, 1);
+		if (createDebug.instances.hasOwnProperty(this.namespace)) {
+			delete createDebug.instances[this.namespace];
 			return true;
 		}
 		return false;
@@ -180,8 +183,10 @@ function setup(env) {
 			}
 		}
 
-		for (i = 0; i < createDebug.instances.length; i++) {
-			const instance = createDebug.instances[i];
+		const keys = Object.keys(createDebug.instances);
+
+		for (i = 0; i < keys.length; i++) {
+			const instance = createDebug.instances[keys[i]];
 			instance.enabled = createDebug.enabled(instance.namespace);
 		}
 	}


### PR DESCRIPTION
Avoiding recreating logger for the namespace which has been already created. Fix memory leak for a fixed number of categories. For dynamic categories method destroy is still required. #678

