### PR TITLE
Add `supports-color` as optional peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,13 @@
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",
-  "browser": "./src/browser.js"
+  "browser": "./src/browser.js",
+  "peerDependencies": {
+    "supports-color": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "supports-color": {
+      "optional": true
+    }
+  }
 }

--- a/src/node.js
+++ b/src/node.js
@@ -23,8 +23,6 @@ exports.useColors = useColors;
 exports.colors = [6, 2, 3, 4, 5, 1];
 
 try {
-	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
-	// eslint-disable-next-line import/no-extraneous-dependencies
 	const supportsColor = require('supports-color');
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {


### PR DESCRIPTION
This is the proper way to declare this type of dependency.

Note that if `peerDependenciesMeta` is not supported by the package
manager (yarn < 1.13 and npm) and `supports-color` is not installed, a warning will be
displayed.

See [`peerDependencies`](https://yarnpkg.com/en/docs/dependency-types#toc-peerdependencies), [`peerDependenciesMeta`](https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md#1130).

Without this, Yarn PnP to throws an error when `debug` is in the dependency tree, since PnP is very strict about `require`ing packages that aren't declared as dependencies.