### PR TITLE
Use util.inspect to format stack traces on Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "karma-mocha": "^1.3.0",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
+    "sinon": "^7.3.2",
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "karma-mocha": "^1.3.0",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
-    "sinon": "^7.3.2",
     "xo": "^0.23.0"
   },
   "main": "./src/index.js",

--- a/src/node.js
+++ b/src/node.js
@@ -235,7 +235,7 @@ function init(debug) {
 }
 
 /**
- * Coerce `val`. In Node.JS, no values need to be coerced (errors are already being formatted for us
+ * Coerce `val`. In Node.js, no values need to be coerced (errors are already being formatted for us
  * by util.format, so this function just returns whatever argument it is given (identitiy function).
  *
  * @param {Mixed} val

--- a/src/node.js
+++ b/src/node.js
@@ -15,6 +15,7 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.coerce = coerce;
 
 /**
  * Colors.
@@ -231,6 +232,18 @@ function init(debug) {
 	for (let i = 0; i < keys.length; i++) {
 		debug.inspectOpts[keys[i]] = exports.inspectOpts[keys[i]];
 	}
+}
+
+/**
+ * Coerce `val`. In Node.JS, no values need to be coerced (errors are already being formatted for us
+ * by util.format, so this function just returns whatever argument it is given (identitiy function).
+ *
+ * @param {Mixed} val
+ * @return {Mixed}
+ * @api private
+ */
+function coerce(val) {
+	return val;
 }
 
 module.exports = require('./common')(exports);

--- a/test.js
+++ b/test.js
@@ -18,7 +18,7 @@ describe('debug', () => {
 		log.enabled = true;
 
 		let loggedMessage;
-		log.log = (msg) => {
+		log.log = msg => {
 			loggedMessage = msg;
 		};
 
@@ -29,8 +29,9 @@ describe('debug', () => {
 
 		// +0ms format for the browser,
 		// ISO8601 format for node.js
-		assert.ok(loggedMessage != null);
-		assert.ok(/(?:.* )?test Error: test\n    at test:1:1(?: +0ms)?/.test(loggedMessage));
+		assert.notStrictEqual(loggedMessage, undefined);
+		assert.notStrictEqual(loggedMessage, null);
+		assert.ok(/(?:.* )?test Error: test\n {4}at test:1:1(?: +0ms)?/.test(loggedMessage));
 	});
 
 	it('allows namespaces to be a non-string value', () => {

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ describe('debug', () => {
 		log(fakeError);
 
 		// +0ms format for the browser,
-		// ISO8601 format for node.js
+		// ISO8601 format for Node.js
 		assert.notStrictEqual(loggedMessage, undefined);
 		assert.notStrictEqual(loggedMessage, null);
 		assert.ok(/(?:.* )?test Error: test\n {4}at test:1:1(?: +0ms)?/.test(loggedMessage));

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ const debug = require('./src');
 
 describe('debug', () => {
 	afterEach(() => {
-		// undo any damage done via sinon mocking
+		// Undo any damage done via sinon mocking
 		sinon.restore();
 	});
 
@@ -18,8 +18,8 @@ describe('debug', () => {
 		assert.doesNotThrow(() => log('hello world'));
 	});
 
-	it('should log errors with full stack', function () {
-		// fake the current time to be 1970-01-01T00:00:00.000Z
+	it('should log errors with full stack', () => {
+		// Fake the current time to be 1970-01-01T00:00:00.000Z
 		sinon.useFakeTimers(new Date(0));
 
 		const log = debug('test');


### PR DESCRIPTION
<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->

This patch ensures we don't manually extract the `stack` or `message` from errors if we are running on Node.js. Instead, `util.inspect`/`util.format` does this for us automatically. The browser behaviour remains unaffected.

I added a unit test to verify the behaviour.

Fixes #711.
