### PR TITLE
process.env is undefined

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -213,7 +213,8 @@ function load() {
 	}
 
 	// If debug isn't set in LS, and we're in Electron, try to load $DEBUG
-	if (!r && typeof process !== 'undefined' && 'env' in process) {
+	// process.env is undefined in sometimes, and it will throw a exception
+	if (!r && typeof process !== 'undefined' && 'env' in process && process.env !== undefined) {
 		r = process.env.DEBUG;
 	}
 


### PR DESCRIPTION
<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->
