### PR TITLE
Marks supports-color as an *optional* peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "mocha-lcov-reporter": "^1.2.0",
     "xo": "^0.23.0"
   },
+  "peerDependenciesMeta": {
+    "supports-color": {
+      "optional": true
+    }
+  },
   "main": "./src/index.js",
   "browser": "./src/browser.js"
 }


### PR DESCRIPTION
This diff adds `supports-color` as an *optional* peer dependency. Optional peer dependencies don't trigger warnings when users omit them. They are supported by all package managers, including npm.

Adding these lines will prevent package managers from incorrectly hoisting `supports-color` in a way that would prevent `debug` from accessing it.