### PR TITLE
Adding support for ReactNative

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -124,7 +124,9 @@ function useColors() {
 		// https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
 		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31) ||
 		// Double check webkit in userAgent just in case we are in a worker
-		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/));
+		(typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().match(/applewebkit\/(\d+)/)) ||
+		// Check if we're being used in ReactNative 
+	    (typeof navigator !== 'undefined' && navigator.product && navigator.product.toLowerCase() === 'reactnative');
 }
 
 /**


### PR DESCRIPTION
ReactNative renders in a document-less mode, but goes through the browser for their live builds.
Fortunately they tag the navigator as ReactNative making this easy to check for.