### PR TITLE
Update common.js

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -10,7 +10,7 @@ function setup(env) {
 	createDebug.coerce = coerce;
 	createDebug.disable = disable;
 	createDebug.enable = enable;
-	createDebug.enabled = enabled;
+	createDebug.enabled = enabled || true;
 	createDebug.humanize = require('ms');
 
 	Object.keys(env).forEach(key => {


### PR DESCRIPTION
<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->
