### PR TITLE
Fix memory leak when creating debug instances

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -9,6 +9,16 @@ exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
 exports.storage = localstorage();
+exports.destroy = (() => {
+	let warned = false;
+
+	return () => {
+		if (!warned) {
+			warned = true;
+			console.warn('Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.');
+		}
+	};
+})();
 
 /**
  * Colors.

--- a/src/common.js
+++ b/src/common.js
@@ -12,6 +12,7 @@ function setup(env) {
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
 	createDebug.humanize = require('ms');
+	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
 		createDebug[key] = env[key];
@@ -114,6 +115,7 @@ function setup(env) {
 		debug.useColors = createDebug.useColors();
 		debug.color = createDebug.selectColor(namespace);
 		debug.extend = extend;
+		debug.destroy = createDebug.destroy; // XXX Temporary. Will be removed in the next major release.
 
 		Object.defineProperty(debug, 'enabled', {
 			enumerable: true,
@@ -241,6 +243,14 @@ function setup(env) {
 			return val.stack || val.message;
 		}
 		return val;
+	}
+
+	/**
+	* XXX DO NOT USE. This is a temporary stub function.
+	* XXX It WILL be removed in the next major release.
+	*/
+	function destroy() {
+		console.warn('Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.');
 	}
 
 	createDebug.enable(createDebug.load());

--- a/src/common.js
+++ b/src/common.js
@@ -18,11 +18,6 @@ function setup(env) {
 	});
 
 	/**
-	* Active `debug` instances.
-	*/
-	createDebug.instances = [];
-
-	/**
 	* The currently active debug mode names, and names to skip.
 	*/
 
@@ -63,6 +58,7 @@ function setup(env) {
 	*/
 	function createDebug(namespace) {
 		let prevTime;
+		let enableOverride = null;
 
 		function debug(...args) {
 			// Disabled?
@@ -115,29 +111,25 @@ function setup(env) {
 		}
 
 		debug.namespace = namespace;
-		debug.enabled = createDebug.enabled(namespace);
 		debug.useColors = createDebug.useColors();
 		debug.color = createDebug.selectColor(namespace);
-		debug.destroy = destroy;
 		debug.extend = extend;
+
+		Object.defineProperty(debug, 'enabled', {
+			enumerable: true,
+			configurable: false,
+			get: () => enableOverride === null ? createDebug.enabled(namespace) : enableOverride,
+			set: v => {
+				enableOverride = v;
+			}
+		});
 
 		// Env-specific initialization logic for debug instances
 		if (typeof createDebug.init === 'function') {
 			createDebug.init(debug);
 		}
 
-		createDebug.instances.push(debug);
-
 		return debug;
-	}
-
-	function destroy() {
-		const index = createDebug.instances.indexOf(this);
-		if (index !== -1) {
-			createDebug.instances.splice(index, 1);
-			return true;
-		}
-		return false;
 	}
 
 	function extend(namespace, delimiter) {
@@ -176,11 +168,6 @@ function setup(env) {
 			} else {
 				createDebug.names.push(new RegExp('^' + namespaces + '$'));
 			}
-		}
-
-		for (i = 0; i < createDebug.instances.length; i++) {
-			const instance = createDebug.instances[i];
-			instance.enabled = createDebug.enabled(instance.namespace);
 		}
 	}
 

--- a/src/node.js
+++ b/src/node.js
@@ -15,6 +15,10 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.destroy = util.deprecate(
+	() => {},
+	'Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.'
+);
 
 /**
  * Colors.

--- a/test.js
+++ b/test.js
@@ -117,5 +117,24 @@ describe('debug', () => {
 			assert.deepStrictEqual(oldNames.map(String), debug.names.map(String));
 			assert.deepStrictEqual(oldSkips.map(String), debug.skips.map(String));
 		});
+
+		it('handles re-enabling existing instances', () => {
+			debug.disable('*');
+			const inst = debug('foo');
+			const messages = [];
+			inst.log = msg => messages.push(msg.replace(/^[^@]*@([^@]+)@.*$/, '$1'));
+
+			inst('@test@');
+			assert.deepStrictEqual(messages, []);
+			debug.enable('foo');
+			assert.deepStrictEqual(messages, []);
+			inst('@test2@');
+			assert.deepStrictEqual(messages, ['test2']);
+			inst('@test3@');
+			assert.deepStrictEqual(messages, ['test2', 'test3']);
+			debug.disable('*');
+			inst('@test4@');
+			assert.deepStrictEqual(messages, ['test2', 'test3']);
+		});
 	});
 });


### PR DESCRIPTION
Closes #678 .

One possible solution to the memory leak and needless `.destroy()` method.

Will leave open for a while to allow people to test.