### PR TITLE
fix(common): escape replaced value

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -99,6 +99,7 @@ function setup(env) {
 				if (typeof formatter === 'function') {
 					const val = args[index];
 					match = formatter.call(self, val);
+					match = match.replace(/%/g, () => '%%');
 
 					// Now we need to remove `args[index]` since it's inlined in the `format`
 					args.splice(index, 1);


### PR DESCRIPTION
Something like this `log('I like %O', { name: '%sugar%' });` will cause output incorrect.