### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "ms": "2.1.2"
+    "ms": "2.1.2",
+    "debug": ">=2.6.9"
   },
   "devDependencies": {
     "brfs": "^2.0.1",


### PR DESCRIPTION
<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->
