### PR TITLE
Instance local caching for "enabled" property (no-leak)

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -9,6 +9,16 @@ exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
 exports.storage = localstorage();
+exports.destroy = (() => {
+	let warned = false;
+
+	return () => {
+		if (!warned) {
+			warned = true;
+			console.warn('Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.');
+		}
+	};
+})();
 
 /**
  * Colors.

--- a/src/common.js
+++ b/src/common.js
@@ -12,6 +12,7 @@ function setup(env) {
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
 	createDebug.humanize = require('ms');
+	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
 		createDebug[key] = env[key];
@@ -114,6 +115,7 @@ function setup(env) {
 		debug.useColors = createDebug.useColors();
 		debug.color = selectColor(namespace);
 		debug.extend = extend;
+		debug.destroy = createDebug.destroy; // XXX Temporary. Will be removed in the next major release.
 
 		Object.defineProperty(debug, 'enabled', {
 			enumerable: true,
@@ -241,6 +243,14 @@ function setup(env) {
 			return val.stack || val.message;
 		}
 		return val;
+	}
+
+	/**
+	* XXX DO NOT USE. This is a temporary stub function.
+	* XXX It WILL be removed in the next major release.
+	*/
+	function destroy() {
+		console.warn('Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.');
 	}
 
 	createDebug.enable(createDebug.load());

--- a/src/common.js
+++ b/src/common.js
@@ -26,6 +26,11 @@ function setup(env) {
 	createDebug.skips = [];
 
 	/**
+	* Revision id of the currently active debug mode names, and names to skip, configuration.
+	*/
+	createDebug.namesRev = '';
+
+	/**
 	* Map of special "%n" handling functions, for the debug "format" argument.
 	*
 	* Valid key names are a single, lower or upper-case letter, i.e. "n" and "N".
@@ -59,7 +64,6 @@ function setup(env) {
 	*/
 	function createDebug(namespace) {
 		let prevTime;
-		let enableOverride = null;
 
 		function debug(...args) {
 			// Disabled?
@@ -119,10 +123,16 @@ function setup(env) {
 
 		Object.defineProperty(debug, 'enabled', {
 			enumerable: true,
-			configurable: false,
-			get: () => enableOverride === null ? createDebug.enabled(namespace) : enableOverride,
-			set: v => {
-				enableOverride = v;
+			get() {
+				if (this._namesRev !== createDebug.namesRev) {
+					this._enabled = createDebug.enabled(namespace);
+					this._namesRev = createDebug.namesRev;
+				}
+				return this._enabled;
+			},
+			set(v) {
+				this._namesRev = createDebug.namesRev;
+				this._enabled = v;
 			}
 		});
 
@@ -152,6 +162,10 @@ function setup(env) {
 
 		createDebug.names = [];
 		createDebug.skips = [];
+
+		// Updates the revision number
+		const now = Date.now().toString(36);
+		createDebug.namesRev = now + (createDebug.namesRev.startsWith(now) ? '_' + (parseInt(createDebug.namesRev.split('_')[1] || '0', 36) + 1).toString(36) : '');
 
 		let i;
 		const split = (typeof namespaces === 'string' ? namespaces : '').split(/[\s,]+/);

--- a/src/node.js
+++ b/src/node.js
@@ -15,6 +15,10 @@ exports.formatArgs = formatArgs;
 exports.save = save;
 exports.load = load;
 exports.useColors = useColors;
+exports.destroy = util.deprecate(
+	() => {},
+	'Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.'
+);
 
 /**
  * Colors.

--- a/test.js
+++ b/test.js
@@ -117,5 +117,24 @@ describe('debug', () => {
 			assert.deepStrictEqual(oldNames.map(String), debug.names.map(String));
 			assert.deepStrictEqual(oldSkips.map(String), debug.skips.map(String));
 		});
+
+		it('handles re-enabling existing instances', () => {
+			debug.disable('*');
+			const inst = debug('foo');
+			const messages = [];
+			inst.log = msg => messages.push(msg.replace(/^[^@]*@([^@]+)@.*$/, '$1'));
+
+			inst('@test@');
+			assert.deepStrictEqual(messages, []);
+			debug.enable('foo');
+			assert.deepStrictEqual(messages, []);
+			inst('@test2@');
+			assert.deepStrictEqual(messages, ['test2']);
+			inst('@test3@');
+			assert.deepStrictEqual(messages, ['test2', 'test3']);
+			debug.disable('*');
+			inst('@test4@');
+			assert.deepStrictEqual(messages, ['test2', 'test3']);
+		});
 	});
 });


### PR DESCRIPTION
I initially overlooked @Qix- fix #740 to issue #678 and came up with almost the same solution, with just the difference the enabled property is managed in a slight different way that:
- caches the status of the enabled property maintaining a stable performance when used in non dynamic context
- do not change the way the enable function interacts with the enabled property

So I'm proposing my fix besides @Qix-'s one as it may add some little value.