### PR TITLE
node: warn when envvar can't be parsed

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -142,6 +142,8 @@ exports.inspectOpts = Object.keys(process.env).filter(key => {
 		val = null;
 	} else {
 		val = Number(val);
+		if (Number.isNaN(val))
+			log(`Cannot parse ${key}=${process.env[key]}`)
 	}
 
 	obj[prop] = val;


### PR DESCRIPTION
Just a minimal message to let devs know that their DEBUG_x variable couldn't be parsed