### PR TITLE
caching enabled status per logger

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -60,7 +60,8 @@ function setup(env) {
 	function createDebug(namespace) {
 		let prevTime;
 		let enableOverride = null;
-		let namespacesCache, enabledCache;
+		let namespacesCache;
+		let enabledCache;
 
 		function debug(...args) {
 			// Disabled?
@@ -123,14 +124,14 @@ function setup(env) {
 			configurable: false,
 			get: () => {
 				if (enableOverride !== null) {
-					return enableOverride
+					return enableOverride;
 				}
 				if (namespacesCache !== createDebug.namespaces) {
 					namespacesCache = createDebug.namespaces;
 					enabledCache = createDebug.enabled(namespace);
 				}
-				return enabledCache;
 
+				return enabledCache;
 			},
 			set: v => {
 				enableOverride = v;

--- a/src/common.js
+++ b/src/common.js
@@ -60,6 +60,7 @@ function setup(env) {
 	function createDebug(namespace) {
 		let prevTime;
 		let enableOverride = null;
+		let namespacesCache, enabledCache;
 
 		function debug(...args) {
 			// Disabled?
@@ -120,7 +121,17 @@ function setup(env) {
 		Object.defineProperty(debug, 'enabled', {
 			enumerable: true,
 			configurable: false,
-			get: () => enableOverride === null ? createDebug.enabled(namespace) : enableOverride,
+			get: () => {
+				if (enableOverride !== null) {
+					return enableOverride
+				}
+				if (namespacesCache !== createDebug.namespaces) {
+					namespacesCache = createDebug.namespaces;
+					enabledCache = createDebug.enabled(namespace);
+				}
+				return enabledCache;
+
+			},
 			set: v => {
 				enableOverride = v;
 			}
@@ -149,6 +160,7 @@ function setup(env) {
 	*/
 	function enable(namespaces) {
 		createDebug.save(namespaces);
+		createDebug.namespaces = namespaces;
 
 		createDebug.names = [];
 		createDebug.skips = [];


### PR DESCRIPTION
Can we have this to avoid rechecking rules on each call?