### PR TITLE
Remove accidental epizeuxis

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -34,7 +34,7 @@ function setup(env) {
 
 	/**
 	* Selects a color for a debug namespace
-	* @param {String} namespace The namespace string for the for the debug instance to be colored
+	* @param {String} namespace The namespace string for the debug instance to be colored
 	* @return {Number|String} An ANSI color code for the given namespace
 	* @api private
 	*/


### PR DESCRIPTION
While reading the source I discovered this sentence, emphasis mine: "the namespace string _for the_ _**for the**_ debug instance to be colored." Epizeuxes are an incredibly powerful technique, but this use seems to fall short of its potential. Also, it was probably an accident.