### PR TITLE
adds README section regarding usage in child procs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,27 @@ if (debug.enabled) {
 You can also manually toggle this property to force the debug instance to be
 enabled or disabled.
 
+## Usage in child processes
+
+Due to the way chalk detects if the output is a TTY or not, colors are not shown in child processes when `stderr` is piped. A solution is to pass the `DEBUG_COLORS=1` environment variable to the child process.  
+For example:
+
+```javascript
+worker = fork(WORKER_WRAP_PATH, [workerPath], {
+  stdio: [
+    /* stdin: */ 0,
+    /* stdout: */ 'pipe',
+    /* stderr: */ 'pipe',
+    'ipc',
+  ],
+  env: Object.assign({}, process.env, {
+    DEBUG_COLORS: 1 // without this settings, colors won't be shown
+  }),
+});
+
+worker.stderr.pipe(process.stderr, { end: false });
+```
+
 
 ## Authors
 


### PR DESCRIPTION
code example and original request copied from @aaarichter
should close #811

<!--

DO NOT SUBMIT PULL REQUESTS REMOVING ES6.

IT WILL BE CLOSED.
IT WILL NOT BE MERGED.

We use ES2015+ for a reason. Modern best
practices dictate the use of tooling like
Babel and @babel/preset-env in order to
target the browsers that make sense for
your project.

For more information, please see:
https://github.com/sindresorhus/ama/issues/446#issuecomment-281014491

-->
