### PR TITLE
fix: prevent re-interpretation of % in formatted output

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -99,9 +99,13 @@ function setup(env) {
 					const val = args[index];
 					match = formatter.call(self, val);
 
-					// Now we need to remove `args[index]` since it's inlined in the `format`
-					args.splice(index, 1);
-					index--;
+					// Replace the original argument with the formatted string
+					// and use %s as a placeholder so that any `%` characters in
+					// the formatted output are not re-interpreted as format
+					// specifiers by the downstream logger (Node's
+					// `util.formatWithOptions` or the browser console).
+					args[index] = match;
+					match = '%s';
 				}
 				return match;
 			});

--- a/test.js
+++ b/test.js
@@ -80,6 +80,80 @@ describe('debug', () => {
 		});
 	});
 
+	describe('percent signs in formatted output (#766, #687)', () => {
+		it('should not re-interpret % in object keys/values with %o', () => {
+			const log = debug('test');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('%o', {'%j': '%j'});
+
+			assert.strictEqual(messages.length, 1);
+			const output = messages[0].join(' ');
+			assert.ok(output.includes('%j'), 'should contain literal %j in output');
+		});
+
+		it('should preserve percent in values with %o', () => {
+			const log = debug('test');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('%o', {key: '100%'});
+
+			assert.strictEqual(messages.length, 1);
+			const output = messages[0].join(' ');
+			assert.ok(output.includes('100%'), 'should contain literal 100% in output');
+		});
+
+		it('should handle mixed specifiers with % in objects', () => {
+			const log = debug('test');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('%s %o', 'hello', {'%d': 1});
+
+			assert.strictEqual(messages.length, 1);
+			const output = messages[0].join(' ');
+			assert.ok(output.includes('hello'), 'should contain hello');
+			assert.ok(output.includes('%d'), 'should contain literal %d in object');
+		});
+
+		it('should still format normal objects with %o', () => {
+			const log = debug('test');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('%o', {a: 1, b: 'test'});
+
+			assert.strictEqual(messages.length, 1);
+			const output = messages[0].join(' ');
+			assert.ok(output.includes('a'), 'should contain key a');
+			assert.ok(output.includes('test'), 'should contain value test');
+		});
+
+		it('should not let %j in data consume extra arguments (#687)', () => {
+			const log = debug('test');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('%o', ['%j']);
+
+			assert.strictEqual(messages.length, 1);
+			const output = messages[0].join(' ');
+			assert.ok(output.includes('%j'), 'should contain literal %j in array output');
+		});
+	});
+
 	describe('rebuild namespaces string (disable)', () => {
 		it('handle names, skips, and wildcards', () => {
 			debug.enable('test,abc*,-abc');


### PR DESCRIPTION
## Summary
Prevent `%` characters in formatted object output from being re-interpreted as format specifiers.

## Problem
When `%o` or `%O` formats an object containing `%` in its keys or values, the stringified output is passed directly into `args[0]`. The downstream logger (`util.formatWithOptions` in Node.js, or `console.log` in browsers) then re-scans the formatted string for `%s`, `%d`, `%j`, etc. specifiers found inside the already-formatted object, consuming subsequent arguments and producing garbled output.

For example:
```js
debug('%o', { '%j': '%j %j %%' }, 1, 2, 3);
// Before: test { '1': '2 3 %' }   (garbled — %j consumed args 1, 2)
// After:  test { '%j': '%j %j %%' } 1 2 3   (correct)
```

## Solution
Instead of inlining the formatter output directly into `args[0]` and removing the original argument, we now replace the original argument in-place with the formatted string and substitute `%s` as a placeholder in the format string. This delegates the final substitution to the downstream logger (`util.formatWithOptions` / `console.log`), which processes `%s` by consuming the next argument — the pre-formatted string — without re-scanning its contents for additional specifiers.

This is a minimal change (3 lines replaced) that preserves backward compatibility with all existing format specifiers.

## Test Plan
- [x] `debug('%o', {'%j': '%j'})` outputs object literally
- [x] `debug('%o', {'key': '100%'})` preserves the percent
- [x] Mixed specifiers with `%` in objects work correctly
- [x] Existing format specifier tests pass (16 pre-existing + 5 new)
- [x] Normal `%o` / `%O` formatting unchanged for objects without `%`

Fixes #766
Fixes #687