### PR TITLE
test: cover disable/enable roundtrip for wildcard namespaces

### DIFF
--- a/test.js
+++ b/test.js
@@ -136,5 +136,16 @@ describe('debug', () => {
 			inst('@test4@');
 			assert.deepStrictEqual(messages, ['test2', 'test3']);
 		});
+
+		it('roundtrips wildcard namespaces from disable() to enable()', () => {
+			debug.enable('*:error:*');
+			assert.deepStrictEqual(debug('test:error:foo').enabled, true);
+			assert.deepStrictEqual(debug('other:warn:bar').enabled, false);
+
+			const namespaces = debug.disable();
+			assert.deepStrictEqual(namespaces, '*:error:*');
+			assert.doesNotThrow(() => debug.enable(namespaces));
+			assert.deepStrictEqual(debug('test:error:foo').enabled, true);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
Add a regression test ensuring wildcard namespace patterns like `*:error:*` survive a `debug.disable()` → `debug.enable()` roundtrip.

## Context
Fixes the scenario reported in #918 where re-enabling namespaces returned by `disable()` could throw `Invalid regular expression: Nothing to repeat`.

Current master already handles this via `matchesTemplate` instead of RegExp conversion; this test locks the behavior in.

## Test plan
- [x] `npm run test:node` — 17 passing