### PR TITLE
test: cover space-separated DEBUG namespace parsing

### DIFF
--- a/test.js
+++ b/test.js
@@ -29,6 +29,16 @@ describe('debug', () => {
 		assert.deepStrictEqual(debug('test:67890').enabled, false);
 	});
 
+	it('enables multiple space-separated namespaces', () => {
+		debug.disable('*');
+
+		debug.enable('APP_X APP_Y APP_Z');
+		assert.deepStrictEqual(debug('APP_X').enabled, true);
+		assert.deepStrictEqual(debug('APP_Y').enabled, true);
+		assert.deepStrictEqual(debug('APP_Z').enabled, true);
+		assert.deepStrictEqual(debug('APP_W').enabled, false);
+	});
+
 	it('uses custom log function', () => {
 		const log = debug('test');
 		log.enabled = true;


### PR DESCRIPTION
## Summary

- Adds regression coverage for `debug.enable('APP_X APP_Y APP_Z')` parsing all space-separated namespaces
- The underlying fix (using `/\s+/g` instead of replacing only the first space) is already on master; this test prevents regressions

## Example

```js
debug.enable('APP_X APP_Y APP_Z');
debug('APP_X').enabled; // true
debug('APP_Y').enabled; // true
debug('APP_Z').enabled; // true
debug('APP_W').enabled; // false
```

Relates to #989

## Test plan

- [x] `npx mocha test.js` — 15 passing