### PR TITLE
fix: honor DEBUG_HIDE_DATE on debug instance inspectOpts

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -165,7 +165,7 @@ function useColors() {
  */
 
 function formatArgs(args) {
-	const {namespace: name, useColors} = this;
+	const {namespace: name, useColors, inspectOpts} = this;
 
 	if (useColors) {
 		const c = this.color;
@@ -175,12 +175,12 @@ function formatArgs(args) {
 		args[0] = prefix + args[0].split('\n').join('\n' + prefix);
 		args.push(colorCode + 'm+' + module.exports.humanize(this.diff) + '\u001B[0m');
 	} else {
-		args[0] = getDate() + name + ' ' + args[0];
+		args[0] = getDate(inspectOpts) + name + ' ' + args[0];
 	}
 }
 
-function getDate() {
-	if (exports.inspectOpts.hideDate) {
+function getDate(inspectOpts) {
+	if (inspectOpts && inspectOpts.hideDate) {
 		return '';
 	}
 	return new Date().toISOString() + ' ';

--- a/test.node.js
+++ b/test.node.js
@@ -36,5 +36,19 @@ describe('debug node', () => {
 			assert.deepStrictEqual(util.formatWithOptions.getCall(0).args[0], options);
 			stdErrWriteStub.restore();
 		});
+
+		it('honors hideDate on debug instance inspectOpts', () => {
+			debug.enable('*');
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			const log = debug('hide date instance');
+			log.useColors = false;
+			log.inspectOpts.hideDate = true;
+			log('hello world3');
+			assert.strictEqual(
+				stdErrWriteStub.getCall(0).args[0],
+				'hide date instance hello world3\n'
+			);
+			stdErrWriteStub.restore();
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Use per-instance `inspectOpts.hideDate` when formatting non-TTY output
- Ensures `DEBUG_HIDE_DATE` (mapped to `hideDate` at init) and manual `inspectOpts` overrides reliably suppress timestamps

Fixes #959

## Test plan
- [x] `npm run test:node`