### PR TITLE
test: cover DEBUG namespace regex metacharacters

### DIFF
--- a/test.js
+++ b/test.js
@@ -136,5 +136,13 @@ describe('debug', () => {
 			inst('@test4@');
 			assert.deepStrictEqual(messages, ['test2', 'test3']);
 		});
+
+		it('does not hang on regex metacharacters in DEBUG', () => {
+			debug.enable('(a+)+$');
+			const start = Date.now();
+			assert.strictEqual(debug.enabled('a'.repeat(30) + 'b'), false);
+			assert(Date.now() - start < 100);
+			debug.disable('*');
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add regression test ensuring `DEBUG` values with regex metacharacters (e.g. `(a+)+$`) do not cause catastrophic backtracking in `enabled()`
- Documents current safe behavior using wildcard template matching instead of regex conversion

Fixes #1033

## Test plan
- [x] `npm run test:node`