### PR TITLE
feat: add option to disable printf-style formatting

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -50,6 +50,34 @@ function setup(env) {
 	}
 	createDebug.selectColor = selectColor;
 
+	function isPrintfOptions(value) {
+		return (
+			value !== null &&
+			typeof value === 'object' &&
+			!Array.isArray(value) &&
+			Object.prototype.hasOwnProperty.call(value, 'printfFormatting')
+		);
+	}
+
+	function resolvePrintfFormatting(args, defaultValue) {
+		const last = args[args.length - 1];
+
+		if (!isPrintfOptions(last)) {
+			return defaultValue !== false;
+		}
+
+		args.pop();
+		return last.printfFormatting !== false;
+	}
+
+	function escapePrintfFormatting(args) {
+		for (let i = 0; i < args.length; i++) {
+			if (typeof args[i] === 'string') {
+				args[i] = args[i].replace(/%/g, '%%');
+			}
+		}
+	}
+
 	/**
 	* Create a debugger with the given `namespace`.
 	*
@@ -70,6 +98,8 @@ function setup(env) {
 			}
 
 			const self = debug;
+			const savedPrintfFormatting = self.printfFormatting;
+			self.printfFormatting = resolvePrintfFormatting(args, savedPrintfFormatting);
 
 			// Set `diff` timestamp
 			const curr = Number(new Date());
@@ -106,11 +136,19 @@ function setup(env) {
 				return match;
 			});
 
+			if (self.printfFormatting === false) {
+				escapePrintfFormatting(args);
+			}
+
 			// Apply env-specific formatting (colors, etc.)
 			createDebug.formatArgs.call(self, args);
 
 			const logFn = self.log || createDebug.log;
-			logFn.apply(self, args);
+			try {
+				logFn.apply(self, args);
+			} finally {
+				self.printfFormatting = savedPrintfFormatting;
+			}
 		}
 
 		debug.namespace = namespace;

--- a/test.js
+++ b/test.js
@@ -43,6 +43,37 @@ describe('debug', () => {
 		assert.deepStrictEqual(messages.length, 3);
 	});
 
+	describe('printf formatting', () => {
+		it('should disable printf formatting with per-call options', () => {
+			const log = debug('sql');
+			log.enabled = true;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('LIKE %fauzi%', {extra: true}, {printfFormatting: false});
+
+			assert.strictEqual(messages.length, 1);
+			assert.match(messages[0][0], /LIKE %%fauzi%%/);
+			assert.deepStrictEqual(messages[0][1], {extra: true});
+		});
+
+		it('should disable printf formatting on the debug instance', () => {
+			const log = debug('sql');
+			log.enabled = true;
+			log.printfFormatting = false;
+
+			const messages = [];
+			log.log = (...args) => messages.push(args);
+
+			log('LIKE %fauzi%', {extra: true});
+
+			assert.strictEqual(messages.length, 1);
+			assert.match(messages[0][0], /LIKE %%fauzi%%/);
+			assert.deepStrictEqual(messages[0][1], {extra: true});
+		});
+	});
+
 	describe('extend namespace', () => {
 		it('should extend namespace', () => {
 			const log = debug('foo');

--- a/test.node.js
+++ b/test.node.js
@@ -36,5 +36,16 @@ describe('debug node', () => {
 			assert.deepStrictEqual(util.formatWithOptions.getCall(0).args[0], options);
 			stdErrWriteStub.restore();
 		});
+
+		it('does not interpret printf specifiers when disabled', () => {
+			debug.enable('*');
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			const log = debug('sql');
+			log('LIKE %fauzi%', {extra: true}, {printfFormatting: false});
+			const output = stdErrWriteStub.getCall(0).args[0];
+			assert.match(output, /LIKE %fauzi%/);
+			assert.doesNotMatch(output, /NaN/);
+			stdErrWriteStub.restore();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Adds per-call `{ printfFormatting: false }` option and instance-level `debug.printfFormatting = false`
- Escapes `%` in log arguments before downstream printf handling so strings like `LIKE %fauzi%` no longer produce `NaN` when extra args are present
- Keeps existing debug formatters (`%o`, `%O`, `%j`) behavior unchanged

## Test plan

- [x] `npm run test:node` (19 tests)
- [x] Regression test for SQL-like `%f` strings with extra args

Closes #976