### PR TITLE
fix: enabled returns undefined instead of false when DEBUG env var is absent

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -161,7 +161,7 @@ function setup(env) {
 	*/
 	function enable(namespaces) {
 		createDebug.save(namespaces);
-		createDebug.namespaces = namespaces;
+		createDebug.namespaces = typeof namespaces === 'string' ? namespaces : '';
 
 		createDebug.names = [];
 		createDebug.skips = [];

--- a/test.js
+++ b/test.js
@@ -137,4 +137,33 @@ describe('debug', () => {
 			assert.deepStrictEqual(messages, ['test2', 'test3']);
 		});
 	});
+
+	describe('enabled before any explicit enable() call', () => {
+		it('returns false (not undefined) when DEBUG env var is absent', () => {
+			// Regression: when enable() is called with undefined (e.g. DEBUG is
+			// not set), createDebug.namespaces is set to undefined.  The per-instance
+			// cache initialises namespacesCache to undefined too, so the cache
+			// comparison `namespacesCache !== createDebug.namespaces` evaluates to
+			// false and enabled() is never invoked, leaving enabledCache as
+			// undefined rather than false.
+			const savedDebug = process.env.DEBUG;
+			delete process.env.DEBUG;
+			// Re-create a fresh debug factory with no DEBUG env var
+			Object.keys(require.cache).forEach(k => {
+				if (k.includes('debug/src')) {
+					delete require.cache[k];
+				}
+			});
+			const freshDebug = require('./src');
+			const log = freshDebug('test:namespace');
+			assert.strictEqual(typeof log.enabled, 'boolean',
+				'enabled should be a boolean, not ' + typeof log.enabled);
+			assert.strictEqual(log.enabled, false,
+				'enabled should be false when no namespaces are active');
+			// Restore
+			if (savedDebug !== undefined) {
+				process.env.DEBUG = savedDebug;
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Problem

When `DEBUG` is not set (or `enable()` is called with a non-string value such as `undefined`), `instance.enabled` incorrectly returns `undefined` instead of `false`.

### Root cause

Inside `enable()`, `createDebug.namespaces` is assigned the raw argument:

```js
createDebug.namespaces = namespaces; // can be undefined
```

Each debug instance caches its enabled state with:

```js
let namespacesCache;   // initialised to undefined
let enabledCache;      // initialised to undefined

get: () => {
  if (namespacesCache !== createDebug.namespaces) { // undefined !== undefined → false!
    namespacesCache = createDebug.namespaces;
    enabledCache = createDebug.enabled(namespace);  // never reached on first access
  }
  return enabledCache; // returns undefined
}
```

Because both `namespacesCache` and `createDebug.namespaces` start as `undefined`, the cache-miss guard evaluates to `false` on the very first access, `createDebug.enabled()` is never called, and `enabledCache` remains `undefined`.

### Observable effect

```js
// No DEBUG env var set
const debug = require('debug');
const log = debug('myapp');

log.enabled              // → undefined  (expected: false)
log.enabled === false    // → false       (expected: true)
typeof log.enabled       // → 'undefined' (expected: 'boolean')
```

The common guard `if (!debug.enabled) return;` still works because `!undefined === true`, but strict comparisons and TypeScript type-checks fail.

## Fix

Normalise `createDebug.namespaces` to an empty string when `enable()` receives a non-string argument, consistent with how the `split` step already handles non-string input:

```js
createDebug.namespaces = typeof namespaces === 'string' ? namespaces : '';
```

This ensures the cache-miss guard fires on the first read after startup, so `enabledCache` is properly initialised.

## Test

A new failing test is added that re-requires `debug` with no `DEBUG` env var and asserts `typeof log.enabled === 'boolean'` and `log.enabled === false`.

> AI-assisted contribution.