### PR TITLE
fix: don't double-process %% before a format specifier

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -86,12 +86,32 @@ function setup(env) {
 				args.unshift('%O');
 			}
 
+			// Count how many arguments the downstream printf-style logger
+			// (`util.formatWithOptions` in Node, `console.*` in browsers) will be
+			// left with after our own `formatters` consume theirs. This decides how
+			// an escaped `%%` must be handled: those loggers only collapse `%%` to a
+			// literal `%` when at least one argument is present, so when arguments
+			// remain we must leave `%%` untouched and let them perform the single,
+			// correct collapse. Collapsing it here as well would re-process the
+			// escape and shift the boundary of any specifier that follows it (e.g.
+			// `debug('%%%s', 'X')` should render `%X`, matching `util.format`).
+			let downstreamArgs = args.length - 1;
+			args[0].replace(/%([a-zA-Z%])/g, (match, format) => {
+				if (match !== '%%' && typeof createDebug.formatters[format] === 'function') {
+					downstreamArgs--;
+				}
+				return match;
+			});
+
 			// Apply any `formatters` transformations
 			let index = 0;
 			args[0] = args[0].replace(/%([a-zA-Z%])/g, (match, format) => {
 				// If we encounter an escaped % then don't increase the array index
 				if (match === '%%') {
-					return '%';
+					// Defer collapsing to the downstream logger when it still has
+					// arguments to format; otherwise it would leave `%%` verbatim,
+					// so collapse it ourselves.
+					return downstreamArgs > 0 ? match : '%';
 				}
 				index++;
 				const formatter = createDebug.formatters[format];

--- a/test.node.js
+++ b/test.node.js
@@ -37,4 +37,45 @@ describe('debug node', () => {
 			stdErrWriteStub.restore();
 		});
 	});
+
+	describe('escaped percent (%%) before a specifier', () => {
+		// Returns the body of the logged line (namespace prefix stripped) so it can
+		// be compared against `util.format`, which the README documents as the
+		// source of truth for `%s`/`%d`/`%j`.
+		function render(template, ...rest) {
+			debug.enable('*');
+			debug.inspectOpts.hideDate = true;
+			debug.inspectOpts.colors = false;
+
+			const stdErrWriteStub = sinon.stub(process.stderr, 'write');
+			try {
+				debug('render')(template, ...rest);
+			} finally {
+				stdErrWriteStub.restore();
+			}
+
+			const line = stdErrWriteStub.getCall(0).args[0].replace(/\n$/, '');
+			const marker = 'render ';
+			return line.slice(line.indexOf(marker) + marker.length);
+		}
+
+		it('keeps parity with util.format for %% followed by a specifier', () => {
+			assert.strictEqual(render('%%%s', 'X'), util.format('%%%s', 'X'));
+			assert.strictEqual(render('100%%%d done', 50), util.format('100%%%d done', 50));
+		});
+
+		it('still collapses %% when no arguments remain', () => {
+			assert.strictEqual(render('100%% done'), '100% done');
+			assert.strictEqual(render('a %% b %% c'), 'a % b % c');
+		});
+
+		it('keeps custom formatters working alongside %%', () => {
+			assert.strictEqual(render('%o %% done', {a: 1}), '{ a: 1 } % done');
+			assert.strictEqual(render('%o %%%s', {a: 1}, 'X'), '{ a: 1 } %X');
+		});
+
+		it('does not collapse %% inside custom formatter output', () => {
+			assert.strictEqual(render('%o', {k: '50%% off'}), '{ k: \'50%% off\' }');
+		});
+	});
 });


### PR DESCRIPTION
## Problem

A literal `%%` immediately followed by a real format specifier is mis-rendered. The README states `debug` uses printf-style formatting and delegates `%s`/`%d`/`%j` to Node's `util.format`, so `util.format` is the source of truth:

```js
const debug = require('debug')('app'); // DEBUG=*, colors off

debug('%%%s', 'X');        // logged: "app %s X"        util.format('%%%s', 'X')        === '%X'
debug('100%%%d done', 50); // logged: "app 100%d done 50"  util.format('100%%%d done', 50) === '100%50 done'
```

The output should match `util.format`. It only breaks for an **even** number of leading `%` before a specifier; odd counts (e.g. `%%s`) were already correct.

## Root cause

`src/common.js` runs `debug`'s own format pass before the result reaches the downstream logger:

```js
args[0] = args[0].replace(/%([a-zA-Z%])/g, (match, format) => {
    if (match === '%%') {
        return '%';   // collapse here
    }
    ...
});
```

That collapsed string is then passed to `util.formatWithOptions` (Node) / `console.*` (browser), which collapse `%%` **again**. The escape is processed twice. For `'%%%s'`, the first pass emits `'%' + '%s'` = `'%%s'`, and `util.format('%%s', 'X')` is `'%s X'`: the specifier boundary has shifted.

The reason `debug` collapses at all is that these loggers only collapse `%%` when **at least one argument is present**:

```js
util.format('100%%')        // '100%%'   (0 args, not collapsed)
util.format('100%%', 'X')   // '100% X'  (1 arg, collapsed)
```

So with zero remaining arguments `debug` has to collapse `%%` itself, otherwise it would leak as `%%`.

## Fix

Decide per-call whether the downstream logger will still have arguments:

- arguments remain → leave `%%` verbatim and let the logger perform the single, correct collapse.
- no arguments remain → collapse `%%` → `%` ourselves, as before.

The remaining-argument count is the original argument count minus those consumed by `debug`'s own custom formatters (`%o`/`%O`/registered), computed before the pass so a `%%` appearing before a custom formatter is decided correctly.

```js
util.format('%%%s', 'X')        // '%X'        ✓
util.format('100%%%d done', 50) // '100%50 done' ✓
```

This keeps `%s`/`%d`/`%j`, custom formatters, separated `%% %s`, zero-arg `100%% done`, and `%%` inside custom-formatter output all correct.

## Relationship to #1028 / #770

Both rewrite the **custom-formatter output** branch so a `%` produced by `%o`/`%O` is not re-interpreted (issue #766). They leave the `%%` escape branch untouched. Applying #1028 on top of current HEAD, `debug('%%%s', 'X')` still logs `%s X`: a separate defect in the `%%` branch, which is what this PR addresses.

## Tests

Added a node test group in `test.node.js` asserting `util.format` parity for `%%` before a specifier, plus the preserved behaviors (zero-arg collapse, custom formatters, formatter-output verbatim). The parity tests fail on `master` and pass with the fix. `test:node` (20) and `test:browser` (14) are green.
