### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
     "rules": {
       "import/extensions": "off"
     }
+  },
+  "homepage": "https://github.com/visionmedia/debug",
+  "bugs": {
+    "url": "https://github.com/visionmedia/debug/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.