### PR TITLE
test: cover wildcard namespace disable round-trip

### DIFF
--- a/test.js
+++ b/test.js
@@ -118,6 +118,16 @@ describe('debug', () => {
 			assert.deepStrictEqual(oldSkips.map(String), debug.skips.map(String));
 		});
 
+		it('round trips wildcard namespaces through enable', () => {
+			debug.enable('*:error:*,-*:error:ignore');
+			const namespaces = debug.disable();
+
+			assert.deepStrictEqual(namespaces, '*:error:*,-*:error:ignore');
+			assert.doesNotThrow(() => debug.enable(namespaces));
+			assert.deepStrictEqual(debug.enabled('api:error:db'), true);
+			assert.deepStrictEqual(debug.enabled('api:error:ignore'), false);
+		});
+
 		it('handles re-enabling existing instances', () => {
 			debug.disable('*');
 			const inst = debug('foo');


### PR DESCRIPTION
## Summary

- add regression coverage for `debug.disable()` namespace strings being accepted by `debug.enable()`
- cover wildcard namespace patterns that start with `*` and include skip patterns
- verify the re-enabled namespace still matches and skips the expected debug names

Closes #918.

## Verification

- `npx mocha test.js --grep 'round trips wildcard namespaces through enable'`
- `npm run test:node`
- touched-file lint: `xo test.js` with Node 24 compatibility shims for this repo's old lint dependencies
- `git diff --check`

`npm run test:browser` was attempted, but the local environment has no `ChromeHeadless` binary and Karma exits with `Please, set "CHROME_BIN" env variable.`
