### PR TITLE
docs: clarify star suffix convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,13 @@ When stdout is not a TTY, `Date#toISOString()` is used, making it more useful fo
 
 ## Conventions
 
-If you're using this in one or more of your libraries, you _should_ use the name of your library so that developers may toggle debugging as desired without guessing names. If you have more than one debuggers you _should_ prefix them with your library name and use ":" to separate features. For example "bodyParser" from Connect would then be "connect:bodyParser".  If you append a "*" to the end of your name, it will always be enabled regardless of the setting of the DEBUG environment variable.  You can then use it for normal output as well as debug output.
+If you're using this in one or more of your libraries, you _should_ use the name
+of your library so that developers may toggle debugging as desired without
+guessing names. If you have more than one debugger you _should_ prefix them with
+your library name and use ":" to separate features. For example "bodyParser"
+from Connect would then be "connect:bodyParser". To enable a group of related
+debuggers, use a wildcard in the `DEBUG` environment variable, such as
+`DEBUG=connect:*`.
 
 ## Wildcards
 


### PR DESCRIPTION
## Summary

- remove the stale README claim that namespace names ending in `*` are always enabled
- clarify that wildcard control should be done through the `DEBUG` environment variable
- keep the change documentation-only and aligned with current behavior

Closes #636.

## Verification

- smoke check proving `debug('connect:*')` is not auto-enabled without `DEBUG`
- smoke check proving `DEBUG=connect:*` enables matching namespaces
- `npm run test:node`
- `git diff --check`
